### PR TITLE
Fix to `camelToSnake` function to handle properly `Some_Snake_Case` string

### DIFF
--- a/gen/generator.go
+++ b/gen/generator.go
@@ -299,6 +299,7 @@ func camelToSnake(name string) string {
 
 	multipleUpper := false
 	var lastUpper rune
+	var beforeUpper rune
 
 	for _, c := range name {
 		// Non-lowercase character after uppercase is considered to be uppercase too.
@@ -312,7 +313,7 @@ func camelToSnake(name string) string {
 			firstInRow := !multipleUpper
 			lastInRow := !isUpper
 
-			if ret.Len() > 0 && (firstInRow || lastInRow) {
+			if ret.Len() > 0 && (firstInRow || lastInRow) && beforeUpper != '_' {
 				ret.WriteByte('_')
 			}
 			ret.WriteRune(unicode.ToLower(lastUpper))
@@ -328,6 +329,7 @@ func camelToSnake(name string) string {
 
 		ret.WriteRune(c)
 		lastUpper = 0
+		beforeUpper = c
 		multipleUpper = false
 	}
 

--- a/gen/generator_test.go
+++ b/gen/generator_test.go
@@ -16,6 +16,8 @@ func TestCamelToSnake(t *testing.T) {
 		{"SomeHTTPStuff", "some_http_stuff"},
 		{"WriteJSON", "write_json"},
 		{"HTTP2Server", "http2_server"},
+		{"Some_Mixed_Case", "some_mixed_case"},
+		{"do_nothing", "do_nothing"},
 
 		{"JSONHTTPRPCServer", "jsonhttprpc_server"}, // nothing can be done here without a dictionary
 	} {


### PR DESCRIPTION
Hi Victor! Thanks for a such good library! :+1: 

Just little fix here.
Some keys could be like `"Some_Mixed_Case"`. Before this fix `camelToSnake` was returning `some__mixed__case` instead of `some_mixed_case`.
