### PR TITLE
Fix for escaping in Writer.String #11

### DIFF
--- a/jwriter/writer.go
+++ b/jwriter/writer.go
@@ -156,11 +156,11 @@ func (w *Writer) String(s string) {
 			}
 		}
 		if escape != 0 {
-			w.Buffer.AppendString(s[p:])
+			w.Buffer.AppendString(s[p:i])
 			w.Buffer.AppendByte('\\')
 			w.Buffer.AppendByte(escape)
 		} else {
-			w.Buffer.AppendString(s[p:])
+			w.Buffer.AppendString(s[p:i])
 			w.Buffer.AppendString(`\u00`)
 			w.Buffer.AppendByte(hex(c >> 4))
 			w.Buffer.AppendByte(hex(c))


### PR DESCRIPTION
Hi! Thanks for the tool! In my case it's relay faster than ffjson)

You had a bug on escaping strings in Marshaler.
E.e. with input `<script type="text/javascript" src="http://example.com/script.js"></script>` marshaling result was `"<script type="text/javascript" src="http://example.com/script.js"></script>\"text/javascript" src="http://example.com/script.js"></script>\" src="http://example.com/script.js"></script>\"http://example.com/script.js"></script>\"></script>"` 

With fix result is `"<script type=\"text/javascript\" src=\"http://example.com/script.js\"></script>"`