### PR TITLE
Ignore struct fields tagged with "-"

### DIFF
--- a/gen/encoder.go
+++ b/gen/encoder.go
@@ -146,9 +146,16 @@ func (g *Generator) genStructFieldEncoder(t reflect.Type, f reflect.StructField)
 	omitEmpty := g.omitEmpty
 
 	for i, s := range strings.Split(f.Tag.Get("json"), ",") {
-		if i > 0 && s == "omitempty" {
+		if i == 0 {
+			if s == "-" {
+				return nil
+			}
+			continue
+		}
+
+		if s == "omitempty" {
 			omitEmpty = true
-		} else if i > 0 && s == "!omitempty" {
+		} else if s == "!omitempty" {
 			omitEmpty = false
 		}
 	}

--- a/tests/basic_test.go
+++ b/tests/basic_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"encoding/json"
+
 	"github.com/mailru/easyjson"
 )
 
@@ -27,6 +28,7 @@ var testCases = []struct {
 	{&rawValue, rawString},
 	{&stdMarshalerValue, stdMarshalerString},
 	{&unexportedStructValue, unexportedStructString},
+	{&excludedFieldValue, excludedFieldString},
 }
 
 func TestMarshal(t *testing.T) {

--- a/tests/data.go
+++ b/tests/data.go
@@ -362,3 +362,14 @@ type unexportedStruct struct {
 
 var unexportedStructValue = unexportedStruct{"test"}
 var unexportedStructString = `{"Value":"test"}`
+
+type ExcludedField struct {
+	Process      bool `json:"process"`
+	DoNotProcess bool `json:"-"`
+}
+
+var excludedFieldValue = ExcludedField{
+	Process:      true,
+	DoNotProcess: false,
+}
+var excludedFieldString = `{"process":true}`


### PR DESCRIPTION
https://golang.org/pkg/encoding/json/#Marshal

> Struct values encode as JSON objects. Each exported struct field becomes a member of the object unless
> 
> - the field's tag is "-", or
> - the field is empty and its tag specifies the "omitempty" option.

This PR implements the "-" part.

Without it I can't use easyjson as a drop-in replacement of the standard JSON marshalling.