### PR TITLE
Add support for Windows paths, fix file handling errors for Windows

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -119,9 +119,13 @@ func (g *Generator) writeMain() (path string, err error) {
 	fmt.Fprintln(f, "  }")
 	fmt.Fprintln(f, "}")
 
-	p := f.Name()
-	os.Rename(p, p+".go")
-	return p + ".go", f.Close()
+	src := f.Name()
+	if err := f.Close(); err != nil {
+		return src, err
+	}
+
+	dest := src + ".go"
+	return dest, os.Rename(src, dest)
 }
 
 func (g *Generator) Run() error {
@@ -144,7 +148,6 @@ func (g *Generator) Run() error {
 	if err != nil {
 		return err
 	}
-	defer f.Close()
 	if !g.LeaveTemps {
 		defer os.Remove(f.Name()) // will not remove after rename
 	}
@@ -155,6 +158,8 @@ func (g *Generator) Run() error {
 	if err = cmd.Run(); err != nil {
 		return err
 	}
+
+	f.Close()
 
 	if !g.NoFormat {
 		cmd = exec.Command("gofmt", "-w", f.Name())

--- a/parser/parser_unix.go
+++ b/parser/parser_unix.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package parser
 
 import (

--- a/parser/parser_windows.go
+++ b/parser/parser_windows.go
@@ -1,0 +1,33 @@
+package parser
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"strings"
+)
+
+func normalizePath(path string) string {
+	return strings.Replace(path, "\\", "/", -1)
+}
+
+func getPkgPath(fname string) (string, error) {
+	if !path.IsAbs(fname) {
+		pwd, err := os.Getwd()
+		if err != nil {
+			return "", err
+		}
+		fname = path.Join(pwd, fname)
+	}
+
+	fname = normalizePath(fname)
+
+	for _, p := range strings.Split(os.Getenv("GOPATH"), ";") {
+		prefix := path.Join(normalizePath(p), "src") + "/"
+		if rel := strings.TrimPrefix(fname, prefix); rel != fname {
+			return path.Dir(rel), nil
+		}
+	}
+
+	return "", fmt.Errorf("file '%v' is not in GOPATH", fname)
+}


### PR DESCRIPTION
This fixes issues that were preventing builds on Windows, specifically:
 - adds rough normalization of paths to work on Windows and Cygwin (backslashes!), where previously it would complain about things not being in the GOPATH
 - fixes two issues where os.Rename fails because rename is attempted before the file is closed

With these fixes it seems to work fine, though I've not done exceedingly thorough testing.