### PR TITLE
Fixed panic in lexer.fetchToken

### DIFF
--- a/jlexer/lexer.go
+++ b/jlexer/lexer.go
@@ -53,6 +53,12 @@ func (r *Lexer) fetchToken() {
 	r.token.kind = tokenUndef
 	r.start = r.pos
 
+	// Check if r.Data has r.pos element
+	// If it doesn't, it mean corrupted input data
+	if len(r.Data) < r.pos {
+		r.errParse("Unexpected end of data")
+		return
+	}
 	// Determine the type of a token by skipping whitespace and reading the
 	// first character.
 	for _, c := range r.Data[r.pos:] {


### PR DESCRIPTION
Incomplete incoming data caused unmarshaler panic: `slice bounds out of range`

E.g. if JSON data is:
```json
{
"somefield": "data",
"anotherfi
```
application crashes with 
```
panic: runtime error: slice bounds out of range

goroutine 1666 [running]:
panic(0xab9740, 0xc82001c040)
	/usr/local/go/src/runtime/panic.go:464 +0x3e6
github.com/mailru/easyjson/jlexer.(*Lexer).fetchToken(0xc820cc6cb0)
	/usr/local/go/src//github.com/mailru/easyjson/jlexer/lexer.go:58 +0x3dc
github.com/mailru/easyjson/jlexer.(*Lexer).IsDelim(0xc820cc6cb0, 0x7d, 0xb95028)
	/usr/local/go/src/github.com/mailru/easyjson/jlexer/lexer.go:427 +0x3a
...
```