### PR TITLE
Reference the gen package from easyjson

### DIFF
--- a/easyjson/main.go
+++ b/easyjson/main.go
@@ -7,6 +7,10 @@ import (
 	"strings"
 
 	"github.com/mailru/easyjson/bootstrap"
+	// Reference the gen package to be friendly to vendoring tools,
+	// as it is an indirect dependency.
+	// (The temporary bootstrapping code uses it.)
+	_ "github.com/mailru/easyjson/gen"
 	"github.com/mailru/easyjson/parser"
 )
 


### PR DESCRIPTION
The generated bootstrapping code requires gen; exposing this
otherwise-indirect dependency makes life easier for people wishing to
vendor easyjson so that they will pull in all the necessary
dependencies.