### PR TITLE
required keys support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,8 @@ generate: root build
 		.root/src/$(PKG)/tests/omitempty.go
 
 	.root/bin/easyjson -all .root/src/$(PKG)/tests/data.go 
-	.root/bin/easyjson -snake_case .root/src/$(PKG)/tests/snake.go 
+	.root/bin/easyjson -all .root/src/$(PKG)/tests/required.go
+	.root/bin/easyjson -snake_case .root/src/$(PKG)/tests/snake.go
 	.root/bin/easyjson -omit_empty .root/src/$(PKG)/tests/omitempty.go 
 	.root/bin/easyjson -build_tags=use_easyjson .root/src/$(PKG)/benchmark/data.go
 

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,6 @@ generate: root build
 		.root/src/$(PKG)/tests/omitempty.go
 
 	.root/bin/easyjson -all .root/src/$(PKG)/tests/data.go 
-	.root/bin/easyjson -all .root/src/$(PKG)/tests/required.go
 	.root/bin/easyjson -snake_case .root/src/$(PKG)/tests/snake.go
 	.root/bin/easyjson -omit_empty .root/src/$(PKG)/tests/omitempty.go 
 	.root/bin/easyjson -build_tags=use_easyjson .root/src/$(PKG)/benchmark/data.go

--- a/gen/decoder.go
+++ b/gen/decoder.go
@@ -170,7 +170,45 @@ func (g *Generator) genStructFieldDecoder(t reflect.Type, f reflect.StructField)
 	}
 
 	fmt.Fprintf(g.out, "    case %q:\n", jsonName)
-	return g.genTypeDecoder(f.Type, "out."+f.Name, tags, 3)
+	if err := g.genTypeDecoder(f.Type, "out."+f.Name, tags, 3); err != nil {
+		return err
+	}
+
+	if tags.required {
+		fmt.Fprintf(g.out, "%sSet = true\n", jsonName)
+	}
+
+	return nil
+}
+
+func (g *Generator) getFieldSetBlock(t reflect.Type, f reflect.StructField) error {
+	jsonName := g.namer.GetJSONFieldName(t, f)
+	tags := parseFieldTags(f)
+
+	if !tags.required {
+		return nil
+	}
+
+	fmt.Fprintf(g.out, "var %sSet bool\n", jsonName)
+
+	return nil
+}
+
+func (g *Generator) getFieldCheckBlock(t reflect.Type, f reflect.StructField) error {
+	jsonName := g.namer.GetJSONFieldName(t, f)
+	tags := parseFieldTags(f)
+
+	if !tags.required {
+		return nil
+	}
+
+	g.imports["fmt"] = "fmt"
+
+	fmt.Fprintf(g.out, "if !%sSet {\n", jsonName)
+	fmt.Fprintf(g.out, "    in.AddError(fmt.Errorf(\"key '%s' is required\"))\n", jsonName)
+	fmt.Fprintf(g.out, "}\n")
+
+	return nil
 }
 
 func mergeStructFields(fields1, fields2 []reflect.StructField) (fields []reflect.StructField) {
@@ -250,6 +288,17 @@ func (g *Generator) genStructDecoder(t reflect.Type) error {
 		fmt.Fprintln(g.out, "  out."+f.Name+" = new("+g.getType(f.Type.Elem())+")")
 	}
 
+	fs, err := getStructFields(t)
+	if err != nil {
+		return fmt.Errorf("cannot generate decoder for %v: %v", t, err)
+	}
+
+	for _, f := range fs {
+		if err := g.getFieldSetBlock(t, f); err != nil {
+			return err
+		}
+	}
+
 	fmt.Fprintln(g.out, "  in.Delim('{')")
 	fmt.Fprintln(g.out, "  for !in.IsDelim('}') {")
 	fmt.Fprintln(g.out, "    key := in.UnsafeString()")
@@ -259,13 +308,8 @@ func (g *Generator) genStructDecoder(t reflect.Type) error {
 	fmt.Fprintln(g.out, "       in.WantComma()")
 	fmt.Fprintln(g.out, "       continue")
 	fmt.Fprintln(g.out, "    }")
+
 	fmt.Fprintln(g.out, "    switch key {")
-
-	fs, err := getStructFields(t)
-	if err != nil {
-		return fmt.Errorf("cannot generate decoder for %v: %v", t, err)
-	}
-
 	for _, f := range fs {
 		if err := g.genStructFieldDecoder(t, f); err != nil {
 			return err
@@ -278,6 +322,13 @@ func (g *Generator) genStructDecoder(t reflect.Type) error {
 	fmt.Fprintln(g.out, "    in.WantComma()")
 	fmt.Fprintln(g.out, "  }")
 	fmt.Fprintln(g.out, "  in.Delim('}')")
+
+	for _, f := range fs {
+		if err := g.getFieldCheckBlock(t, f); err != nil {
+			return err
+		}
+	}
+
 	fmt.Fprintln(g.out, "}")
 
 	return nil

--- a/gen/encoder.go
+++ b/gen/encoder.go
@@ -52,6 +52,7 @@ type fieldTags struct {
 	omitEmpty   bool
 	noOmitEmpty bool
 	asString    bool
+	required    bool
 }
 
 // parseFieldTags parses the json field tag into a structure.
@@ -70,6 +71,8 @@ func parseFieldTags(f reflect.StructField) fieldTags {
 			ret.noOmitEmpty = true
 		case s == "string":
 			ret.asString = true
+		case s == "required":
+			ret.required = true
 		}
 	}
 

--- a/tests/data.go
+++ b/tests/data.go
@@ -435,3 +435,8 @@ var mapsString = `{` +
 	`"NilMap":null,` +
 	`"CustomMap":{"c":"d"}` +
 	`}`
+
+type RequiredOptionalStruct struct {
+	FirstName string `json:"first_name,required"`
+	Lastname  string `json:"last_name"`
+}

--- a/tests/required.go
+++ b/tests/required.go
@@ -1,7 +1,0 @@
-package tests
-
-//easyjson:json
-type RequiredOptionalStruct struct {
-	FirstName string `json:"first_name,required"`
-	Lastname  string `json:"last_name"`
-}

--- a/tests/required.go
+++ b/tests/required.go
@@ -1,0 +1,7 @@
+package tests
+
+//easyjson:json
+type RequiredOptionalStruct struct {
+	FirstName string `json:"first_name,required"`
+	Lastname  string `json:"last_name"`
+}

--- a/tests/required_test.go
+++ b/tests/required_test.go
@@ -1,0 +1,28 @@
+package tests
+
+import (
+	"testing"
+	"fmt"
+)
+
+func TestRequiredField(t *testing.T) {
+	cases := []struct{ json, errorMessage string }{
+		{`{"first_name":"Foo", "last_name": "Bar"}`, ""},
+		{`{"last_name":"Bar"}`, "key 'first_name' is required"},
+		{"{}", "key 'first_name' is required"},
+	}
+
+	for _, tc := range cases {
+		var v RequiredOptionalStruct
+		err := v.UnmarshalJSON([]byte(tc.json))
+		if tc.errorMessage == "" {
+			if err != nil {
+				t.Errorf("%s. UnmarshallJSON didn`t expect error: %v", tc.json, err)
+			}
+		} else {
+			if fmt.Sprintf("%v", err) != tc.errorMessage {
+				t.Errorf("%s. UnmarshallJSON expected error: %v. got: %v", tc.json, tc.errorMessage, err)
+			}
+		}
+	}
+}


### PR DESCRIPTION
I`ve done very straight forward implementation for required keys as we discussed in #24

So for struct
```go
type Person struct {
	Firstname string `json:"first_name,required"`
	Lastname  string `json:"last_name"`
}
```
this code will be generated:
```go
func easyjson_4f3adcb_decode_github_com_mailru_easyjson_tests_RequiredOptionalStruct(in *jlexer.Lexer, out *RequiredOptionalStruct) {
	if in.IsNull() {
		in.Skip()
		return
	}
	var first_nameSet bool
	in.Delim('{')
	for !in.IsDelim('}') {
		key := in.UnsafeString()
		in.WantColon()
		if in.IsNull() {
			in.Skip()
			in.WantComma()
			continue
		}
		switch key {
		case "first_name":
			out.FirstName = string(in.String())
			first_nameSet = true
		case "last_name":
			out.Lastname = string(in.String())
		default:
			in.SkipRecursive()
		}
		in.WantComma()
	}
	in.Delim('}')
	if !first_nameSet {
		in.AddError(fmt.Errorf("key 'first_name' is required"))
	}
}
```

It adds %sSet bool variable which shows if key presented in json or not.