### PR TITLE
Creates LexerError type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .root
 *_easyjson.go
+*.iml
+.idea

--- a/jlexer/error.go
+++ b/jlexer/error.go
@@ -1,0 +1,15 @@
+package jlexer
+
+import "fmt"
+
+// LexerError implements the error interface and represents all possible errors that can be
+// generated during parsing the JSON data.
+type LexerError struct {
+	Reason string
+	Offset int
+	Data   string
+}
+
+func (l *LexerError) Error() string {
+	return fmt.Sprintf("parse error: %s near offset %d of '%s'", l.Reason, l.Offset, l.Data)
+}

--- a/jlexer/lexer.go
+++ b/jlexer/lexer.go
@@ -396,7 +396,11 @@ func (r *Lexer) errParse(what string) {
 		} else {
 			str = string(r.Data[r.pos:r.pos+maxErrorContextLen-3]) + "..."
 		}
-		r.err = fmt.Errorf("parse error: %s at byte %d, near '%s'.", what, r.pos, str)
+		r.err = &LexerError{
+			Reason: what,
+			Offset: r.pos,
+			Data:   str,
+		}
 	}
 }
 
@@ -412,7 +416,11 @@ func (r *Lexer) errInvalidToken(expected string) {
 		} else {
 			str = string(r.token.byteValue[:maxErrorContextLen-3]) + "..."
 		}
-		r.err = fmt.Errorf("parse error: expected %s, got '%s' at byte %d.", expected, str, r.start)
+		r.err = &LexerError{
+			Reason: fmt.Sprintf("expected %s", expected),
+			Offset: r.pos,
+			Data:   str,
+		}
 	}
 }
 
@@ -586,8 +594,13 @@ func (r *Lexer) Uint8() uint8 {
 	if !r.Ok() {
 		return 0
 	}
-	var n uint64
-	n, r.err = strconv.ParseUint(s, 10, 8)
+
+	n, err := strconv.ParseUint(s, 10, 8)
+	if err != nil {
+		r.err = &LexerError{
+			Reason: err.Error(),
+		}
+	}
 	return uint8(n)
 }
 
@@ -596,8 +609,13 @@ func (r *Lexer) Uint16() uint16 {
 	if !r.Ok() {
 		return 0
 	}
-	var n uint64
-	n, r.err = strconv.ParseUint(s, 10, 16)
+
+	n, err := strconv.ParseUint(s, 10, 16)
+	if err != nil {
+		r.err = &LexerError{
+			Reason: err.Error(),
+		}
+	}
 	return uint16(n)
 }
 
@@ -606,8 +624,13 @@ func (r *Lexer) Uint32() uint32 {
 	if !r.Ok() {
 		return 0
 	}
-	var n uint64
-	n, r.err = strconv.ParseUint(s, 10, 32)
+
+	n, err := strconv.ParseUint(s, 10, 32)
+	if err != nil {
+		r.err = &LexerError{
+			Reason: err.Error(),
+		}
+	}
 	return uint32(n)
 }
 
@@ -616,8 +639,13 @@ func (r *Lexer) Uint64() uint64 {
 	if !r.Ok() {
 		return 0
 	}
-	var n uint64
-	n, r.err = strconv.ParseUint(s, 10, 64)
+
+	n, err := strconv.ParseUint(s, 10, 64)
+	if err != nil {
+		r.err = &LexerError{
+			Reason: err.Error(),
+		}
+	}
 	return n
 }
 
@@ -630,8 +658,13 @@ func (r *Lexer) Int8() int8 {
 	if !r.Ok() {
 		return 0
 	}
-	var n int64
-	n, r.err = strconv.ParseInt(s, 10, 8)
+
+	n, err := strconv.ParseInt(s, 10, 8)
+	if err != nil {
+		r.err = &LexerError{
+			Reason: err.Error(),
+		}
+	}
 	return int8(n)
 }
 
@@ -640,8 +673,13 @@ func (r *Lexer) Int16() int16 {
 	if !r.Ok() {
 		return 0
 	}
-	var n int64
-	n, r.err = strconv.ParseInt(s, 10, 16)
+
+	n, err := strconv.ParseInt(s, 10, 16)
+	if err != nil {
+		r.err = &LexerError{
+			Reason: err.Error(),
+		}
+	}
 	return int16(n)
 }
 
@@ -650,8 +688,13 @@ func (r *Lexer) Int32() int32 {
 	if !r.Ok() {
 		return 0
 	}
-	var n int64
-	n, r.err = strconv.ParseInt(s, 10, 32)
+
+	n, err := strconv.ParseInt(s, 10, 32)
+	if err != nil {
+		r.err = &LexerError{
+			Reason: err.Error(),
+		}
+	}
 	return int32(n)
 }
 
@@ -660,8 +703,13 @@ func (r *Lexer) Int64() int64 {
 	if !r.Ok() {
 		return 0
 	}
-	var n int64
-	n, r.err = strconv.ParseInt(s, 10, 64)
+
+	n, err := strconv.ParseInt(s, 10, 64)
+	if err != nil {
+		r.err = &LexerError{
+			Reason: err.Error(),
+		}
+	}
 	return n
 }
 
@@ -674,8 +722,13 @@ func (r *Lexer) Uint8Str() uint8 {
 	if !r.Ok() {
 		return 0
 	}
-	var n uint64
-	n, r.err = strconv.ParseUint(s, 10, 8)
+
+	n, err := strconv.ParseUint(s, 10, 8)
+	if err != nil {
+		r.err = &LexerError{
+			Reason: err.Error(),
+		}
+	}
 	return uint8(n)
 }
 
@@ -684,8 +737,13 @@ func (r *Lexer) Uint16Str() uint16 {
 	if !r.Ok() {
 		return 0
 	}
-	var n uint64
-	n, r.err = strconv.ParseUint(s, 10, 16)
+
+	n, err := strconv.ParseUint(s, 10, 16)
+	if err != nil {
+		r.err = &LexerError{
+			Reason: err.Error(),
+		}
+	}
 	return uint16(n)
 }
 
@@ -694,8 +752,13 @@ func (r *Lexer) Uint32Str() uint32 {
 	if !r.Ok() {
 		return 0
 	}
-	var n uint64
-	n, r.err = strconv.ParseUint(s, 10, 32)
+
+	n, err := strconv.ParseUint(s, 10, 32)
+	if err != nil {
+		r.err = &LexerError{
+			Reason: err.Error(),
+		}
+	}
 	return uint32(n)
 }
 
@@ -704,8 +767,13 @@ func (r *Lexer) Uint64Str() uint64 {
 	if !r.Ok() {
 		return 0
 	}
-	var n uint64
-	n, r.err = strconv.ParseUint(s, 10, 64)
+
+	n, err := strconv.ParseUint(s, 10, 64)
+	if err != nil {
+		r.err = &LexerError{
+			Reason: err.Error(),
+		}
+	}
 	return n
 }
 
@@ -718,8 +786,13 @@ func (r *Lexer) Int8Str() int8 {
 	if !r.Ok() {
 		return 0
 	}
-	var n int64
-	n, r.err = strconv.ParseInt(s, 10, 8)
+
+	n, err := strconv.ParseInt(s, 10, 8)
+	if err != nil {
+		r.err = &LexerError{
+			Reason: err.Error(),
+		}
+	}
 	return int8(n)
 }
 
@@ -728,8 +801,13 @@ func (r *Lexer) Int16Str() int16 {
 	if !r.Ok() {
 		return 0
 	}
-	var n int64
-	n, r.err = strconv.ParseInt(s, 10, 16)
+
+	n, err := strconv.ParseInt(s, 10, 16)
+	if err != nil {
+		r.err = &LexerError{
+			Reason: err.Error(),
+		}
+	}
 	return int16(n)
 }
 
@@ -738,8 +816,13 @@ func (r *Lexer) Int32Str() int32 {
 	if !r.Ok() {
 		return 0
 	}
-	var n int64
-	n, r.err = strconv.ParseInt(s, 10, 32)
+
+	n, err := strconv.ParseInt(s, 10, 32)
+	if err != nil {
+		r.err = &LexerError{
+			Reason: err.Error(),
+		}
+	}
 	return int32(n)
 }
 
@@ -748,8 +831,13 @@ func (r *Lexer) Int64Str() int64 {
 	if !r.Ok() {
 		return 0
 	}
-	var n int64
-	n, r.err = strconv.ParseInt(s, 10, 64)
+
+	n, err := strconv.ParseInt(s, 10, 64)
+	if err != nil {
+		r.err = &LexerError{
+			Reason: err.Error(),
+		}
+	}
 	return n
 }
 
@@ -762,8 +850,13 @@ func (r *Lexer) Float32() float32 {
 	if !r.Ok() {
 		return 0
 	}
-	var n float64
-	n, r.err = strconv.ParseFloat(s, 32)
+
+	n, err := strconv.ParseFloat(s, 32)
+	if err != nil {
+		r.err = &LexerError{
+			Reason: err.Error(),
+		}
+	}
 	return float32(n)
 }
 
@@ -772,8 +865,13 @@ func (r *Lexer) Float64() float64 {
 	if !r.Ok() {
 		return 0
 	}
-	var n float64
-	n, r.err = strconv.ParseFloat(s, 64)
+
+	n, err := strconv.ParseFloat(s, 64)
+	if err != nil {
+		r.err = &LexerError{
+			Reason: err.Error(),
+		}
+	}
 	return n
 }
 


### PR DESCRIPTION
# What

- Creates LexerError type for all possible parse errors generated by the
  Lexer, except for standard JSON library errors or through AddError
  method;
- Updates .gitignore to exclude JetBrain family directories and files.

# Why

The `Lexer` type simply returns errors using `fmt.Errorf`, while this is fine and functional, it's often challenging for library users to know what the error really is unless we sniff into the string. Having a typed error improves the usage of the library. Consider the following snippet:

```go
func SomeBigFunc(input []byte) error {
  if input == "some special case" {
    return &SomeSpecificError{}
  }

  err := easyjson.Unmarshal(input, someGoodVar)
  if err != nil {
    // I would like to handler the error, but I don't have enough information to handle it here, so I send it up.
    return err
  }

  // Do more stuff
  return nil
}
```

Now, when someone calls `SomeBigFunc` and get an error, it cannot identify that this is because of an error in JSON parsing.

This PR is very basic, but it at least allow us to do checks like:

```go
err := SomeBigFunc("")
if _, ok := err.(*jlexer.LexerError); !ok {
  // Do something.
}
```