### PR TITLE
Fix generating valid files with no types to marshal/unmarshal in file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,9 +20,11 @@ generate: root build
 	.root/bin/easyjson -stubs \
 		.root/src/$(PKG)/tests/snake.go \
 		.root/src/$(PKG)/tests/data.go \
-		.root/src/$(PKG)/tests/omitempty.go
+		.root/src/$(PKG)/tests/omitempty.go \
+		.root/src/$(PKG)/tests/nothing.go
 
 	.root/bin/easyjson -all .root/src/$(PKG)/tests/data.go 
+	.root/bin/easyjson -all .root/src/$(PKG)/tests/nothing.go
 	.root/bin/easyjson -snake_case .root/src/$(PKG)/tests/snake.go
 	.root/bin/easyjson -omit_empty .root/src/$(PKG)/tests/omitempty.go 
 	.root/bin/easyjson -build_tags=use_easyjson .root/src/$(PKG)/benchmark/data.go

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -50,11 +50,14 @@ func (g *Generator) writeStub() error {
 	fmt.Fprintln(f, "// compilable during generation.")
 	fmt.Fprintln(f)
 	fmt.Fprintln(f, "package ", g.PkgName)
-	fmt.Fprintln(f)
-	fmt.Fprintln(f, "import (")
-	fmt.Fprintln(f, `  "`+pkgWriter+`"`)
-	fmt.Fprintln(f, `  "`+pkgLexer+`"`)
-	fmt.Fprintln(f, ")")
+
+	if len(g.Types) > 0 {
+		fmt.Fprintln(f)
+		fmt.Fprintln(f, "import (")
+		fmt.Fprintln(f, `  "`+pkgWriter+`"`)
+		fmt.Fprintln(f, `  "`+pkgLexer+`"`)
+		fmt.Fprintln(f, ")")
+	}
 
 	for _, t := range g.Types {
 		fmt.Fprintln(f)
@@ -90,8 +93,10 @@ func (g *Generator) writeMain() (path string, err error) {
 	fmt.Fprintln(f, `  "os"`)
 	fmt.Fprintln(f)
 	fmt.Fprintf(f, "  %q\n", genPackage)
-	fmt.Fprintln(f)
-	fmt.Fprintf(f, "  pkg %q\n", g.PkgPath)
+	if len(g.Types) > 0 {
+		fmt.Fprintln(f)
+		fmt.Fprintf(f, "  pkg %q\n", g.PkgPath)
+	}
 	fmt.Fprintln(f, ")")
 	fmt.Fprintln(f)
 	fmt.Fprintln(f, "func main() {")

--- a/gen/generator.go
+++ b/gen/generator.go
@@ -156,7 +156,12 @@ func (g *Generator) printHeader() {
 
 	fmt.Println(")")
 	fmt.Println("")
-	fmt.Println("var _ = json.RawMessage{} // suppress unused package warning")
+	fmt.Println("// suppress unused package warning")
+	fmt.Println("var (")
+	fmt.Println("   _ = json.RawMessage{}")
+	fmt.Println("   _ = jlexer.Lexer{}")
+	fmt.Println("   _ = jwriter.Writer{}")
+	fmt.Println(")")
 
 	fmt.Println()
 }

--- a/tests/nothing.go
+++ b/tests/nothing.go
@@ -1,0 +1,3 @@
+package tests
+
+// No structs in this file


### PR DESCRIPTION
If the file doesn't contain any structs for generator, generated file becomes invalid, because it contains imports which are not used (jlexer and jwriter are always imported). It makes difficult to use easyjson for batch generation on directory which may contain some files without structs (or without //easyjson:json comment).