### PR TITLE
port original golang string encoder with broken utf processing

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -5,3 +5,9 @@ Permission is hereby granted, free of charge, to any person obtaining a copy of 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+Part of this jwriter/writer.go uses code from original golang encoding/json
+Copyright 2010 The Go Authors.  All rights reserved.
+Use of this source code is governed by a BSD-style
+license that can be found in the LICENSE file.

--- a/jwriter/writer.go
+++ b/jwriter/writer.go
@@ -1,18 +1,23 @@
 // Package jwriter contains a JSON writer.
+
+// Part of this file uses code from original golang encoding/json
+// Copyright 2010 The Go Authors.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 package jwriter
 
 import (
+	"github.com/mailru/easyjson/buffer"
 	"io"
 	"strconv"
-
-	"github.com/mailru/easyjson/buffer"
+	"unicode/utf8"
 )
 
 // Writer is a JSON writer.
 type Writer struct {
-	EscapeLtGt bool
-	Error      error
-	Buffer     buffer.Buffer
+	Error  error
+	Buffer buffer.Buffer
 }
 
 // Size returns the size of the data that was written out.
@@ -198,55 +203,80 @@ func (w *Writer) Bool(v bool) {
 	}
 }
 
-func hex(c byte) byte {
-	const chars = "0123456789abcdef"
-	return chars[c&0xf]
-}
+const hex = "0123456789abcdef"
 
+/**
+ * Port from original golang encoding/json: func (e *encodeState) string(s string) (int, error)
+ */
 func (w *Writer) String(s string) {
 	w.Buffer.AppendByte('"')
-
-	// Portions of the string that contain no escapes are appended as
-	// byte slices.
-
-	p := 0 // last non-escape symbol
-
-	for i := 0; i < len(s); i++ {
-		c := s[i]
-		var escape byte
-		switch c {
-		case '\t':
-			escape = 't'
-		case '\r':
-			escape = 'r'
-		case '\n':
-			escape = 'n'
-		case '\\':
-			escape = '\\'
-		case '"':
-			escape = '"'
-		case '<', '>':
-			if !w.EscapeLtGt {
+	start := 0
+	for i := 0; i < len(s); {
+		if b := s[i]; b < utf8.RuneSelf {
+			if 0x20 <= b && b != '\\' && b != '"' && b != '<' && b != '>' && b != '&' {
+				i++
 				continue
 			}
-		default:
-			if c >= 0x20 {
-				// no escaping is required
-				continue
+			if start < i {
+				w.Buffer.AppendString(s[start:i])
 			}
+			switch b {
+			case '\\', '"':
+				w.Buffer.AppendByte('\\')
+				w.Buffer.AppendByte(b)
+			case '\n':
+				w.Buffer.AppendByte('\\')
+				w.Buffer.AppendByte('n')
+			case '\r':
+				w.Buffer.AppendByte('\\')
+				w.Buffer.AppendByte('r')
+			case '\t':
+				w.Buffer.AppendByte('\\')
+				w.Buffer.AppendByte('t')
+			default:
+				// This encodes bytes < 0x20 except for \n and \r,
+				// as well as <, > and &. The latter are escaped because they
+				// can lead to security holes when user-controlled strings
+				// are rendered into JSON and served to some browsers.
+				w.Buffer.AppendString(`\u00`)
+				w.Buffer.AppendByte(hex[b>>4])
+				w.Buffer.AppendByte(hex[b&0xf])
+			}
+			i++
+			start = i
+			continue
 		}
-		if escape != 0 {
-			w.Buffer.AppendString(s[p:i])
-			w.Buffer.AppendByte('\\')
-			w.Buffer.AppendByte(escape)
-		} else {
-			w.Buffer.AppendString(s[p:i])
-			w.Buffer.AppendString(`\u00`)
-			w.Buffer.AppendByte(hex(c >> 4))
-			w.Buffer.AppendByte(hex(c))
+		c, size := utf8.DecodeRuneInString(s[i:])
+		if c == utf8.RuneError && size == 1 {
+			if start < i {
+				w.Buffer.AppendString(s[start:i])
+			}
+			w.Buffer.AppendString(`\ufffd`)
+			i += size
+			start = i
+			continue
 		}
-		p = i + 1
+		// U+2028 is LINE SEPARATOR.
+		// U+2029 is PARAGRAPH SEPARATOR.
+		// They are both technically valid characters in JSON strings,
+		// but don't work in JSONP, which has to be evaluated as JavaScript,
+		// and can lead to security holes there. It is valid JSON to
+		// escape them, so we do so unconditionally.
+		// See http://timelessrepo.com/json-isnt-a-javascript-subset for discussion.
+		if c == '\u2028' || c == '\u2029' {
+			if start < i {
+				w.Buffer.AppendString(s[start:i])
+			}
+			w.Buffer.AppendString(`\u202`)
+			w.Buffer.AppendByte(hex[c&0xf])
+			i += size
+			start = i
+			continue
+		}
+		i += size
 	}
-	w.Buffer.AppendString(s[p:])
+	if start < len(s) {
+		w.Buffer.AppendString(s[start:])
+	}
 	w.Buffer.AppendByte('"')
 }

--- a/tests/basic_test.go
+++ b/tests/basic_test.go
@@ -105,24 +105,21 @@ func TestParseNull(t *testing.T) {
 	}
 }
 
-var testCasesEncodeLtGt = []struct {
-	Writer  *jwriter.Writer
-	Encoded string
+var testSpecialCases = []struct {
+	String string
+	Value string
 }{
-	{&jwriter.Writer{
-		EscapeLtGt: false,
-	}, encodeLtGtFalseWantString},
-	{&jwriter.Writer{
-		EscapeLtGt: true,
-	}, encodeLtGtTrueWantString},
+	{LtGtString, LtGtValue},
+	{BrokenUtfString, BrokenUtfValue},
 }
 
-func TestEncodeLtGt(t *testing.T) {
-	for i, test := range testCasesEncodeLtGt {
-		test.Writer.String(encodeLtGtString)
-		got := string(test.Writer.Buffer.BuildBytes())
-		if got != test.Encoded {
-			t.Errorf("[%d] Encoded() = %+v; want %+v", i, got, test.Encoded)
+func TestSpecialCases(t *testing.T) {
+	for i, test := range testSpecialCases {
+		w := jwriter.Writer{}
+		w.String(test.Value)
+		got := string(w.Buffer.BuildBytes())
+		if got != test.String {
+			t.Errorf("[%d] Encoded() = %+v; want %+v", i, got, test.String)
 		}
 	}
 }

--- a/tests/data.go
+++ b/tests/data.go
@@ -471,6 +471,8 @@ type RequiredOptionalStruct struct {
 	Lastname  string `json:"last_name"`
 }
 
-var encodeLtGtString = `Username <user@example.com>`
-var encodeLtGtFalseWantString = `"Username <user@example.com>"`
-var encodeLtGtTrueWantString = `"Username \u003cuser@example.com\u003e"`
+var LtGtValue = `Username <user@example.com>`
+var LtGtString = `"Username \u003cuser@example.com\u003e"`
+
+var BrokenUtfValue = "Username\xc5"
+var BrokenUtfString = `"Username\ufffd"`


### PR DESCRIPTION
remove old "<" and ">" encoding option - dont think it necessary if original encoder process them