### PR TITLE
Fix generated code for named types

### DIFF
--- a/gen/decoder.go
+++ b/gen/decoder.go
@@ -86,7 +86,7 @@ func (g *Generator) genTypeDecoder(t reflect.Type, out string, tags fieldTags, i
 
 		fmt.Fprintln(g.out, ws+"in.Delim('[')")
 		fmt.Fprintln(g.out, ws+"if !in.IsDelim(']') {")
-		fmt.Fprintln(g.out, ws+"  "+out+" = make([]"+g.getType(elem)+", 0, "+fmt.Sprint(capacity)+")")
+		fmt.Fprintln(g.out, ws+"  "+out+" = make("+g.getType(t)+", 0, "+fmt.Sprint(capacity)+")")
 		fmt.Fprintln(g.out, ws+"} else {")
 		fmt.Fprintln(g.out, ws+"  "+out+" = nil")
 		fmt.Fprintln(g.out, ws+"}")
@@ -130,7 +130,7 @@ func (g *Generator) genTypeDecoder(t reflect.Type, out string, tags fieldTags, i
 		fmt.Fprintln(g.out, ws+"} else {")
 		fmt.Fprintln(g.out, ws+"  in.Delim('{')")
 		fmt.Fprintln(g.out, ws+"  if !in.IsDelim('}') {")
-		fmt.Fprintln(g.out, ws+"  "+out+" = make(map["+g.getType(t.Key())+"]"+g.getType(t.Elem())+")")
+		fmt.Fprintln(g.out, ws+"  "+out+" = make("+g.getType(t)+")")
 		fmt.Fprintln(g.out, ws+"  } else {")
 		fmt.Fprintln(g.out, ws+"  "+out+" = nil")
 		fmt.Fprintln(g.out, ws+"  }")

--- a/gen/generator.go
+++ b/gen/generator.go
@@ -222,13 +222,15 @@ func (g *Generator) pkgAlias(pkgPath string) string {
 
 // getType return the textual type name of given type that can be used in generated code.
 func (g *Generator) getType(t reflect.Type) string {
-	switch t.Kind() {
-	case reflect.Ptr:
-		return "*" + g.getType(t.Elem())
-	case reflect.Slice:
-		return "[]" + g.getType(t.Elem())
-	case reflect.Map:
-		return "map[" + g.getType(t.Key()) + "]" + g.getType(t.Elem())
+	if t.Name() == "" {
+		switch t.Kind() {
+		case reflect.Ptr:
+			return "*" + g.getType(t.Elem())
+		case reflect.Slice:
+			return "[]" + g.getType(t.Elem())
+		case reflect.Map:
+			return "map[" + g.getType(t.Key()) + "]" + g.getType(t.Elem())
+		}
 	}
 
 	if t.Name() == "" || t.PkgPath() == "" {

--- a/tests/data.go
+++ b/tests/data.go
@@ -436,38 +436,88 @@ var mapsString = `{` +
 	`"CustomMap":{"c":"d"}` +
 	`}`
 
+type NamedSlice []Str
+type NamedMap map[Str]Str
+
 type DeepNest struct {
-	SliceMap  map[Str][]Str
-	SliceMap1 map[Str][]Str
-	MapSlice  []map[Str]Str
+	SliceMap        map[Str][]Str
+	SliceMap1       map[Str][]Str
+	NamedSliceMap   map[Str]NamedSlice
+	NamedMapMap     map[Str]NamedMap
+	MapSlice        []map[Str]Str
+	NamedSliceSlice []NamedSlice
+	NamedMapSlice   []NamedMap
 }
 
 var deepNestValue = DeepNest{
 	SliceMap: map[Str][]Str{
-		"testSliceMap1": []Str{
+		"testSliceMap": []Str{
 			"0",
 			"1",
 		},
 	},
 	SliceMap1: map[Str][]Str{
-		"testSliceMap2": nil,
+		"testSliceMap1": nil,
+	},
+	NamedSliceMap: map[Str]NamedSlice{
+		"testNamedSliceMap": NamedSlice{
+			"2",
+			"3",
+		},
+	},
+	NamedMapMap: map[Str]NamedMap{
+		"testNamedMapMap": NamedMap{
+			"key1": "value1",
+		},
 	},
 	MapSlice: []map[Str]Str{
 		map[Str]Str{
-			"testMapSlice1": "someValue",
+			"testMapSlice": "someValue",
+		},
+	},
+	NamedSliceSlice: []NamedSlice{
+		NamedSlice{
+			"someValue1",
+			"someValue2",
+		},
+		NamedSlice{
+			"someValue3",
+			"someValue4",
+		},
+	},
+	NamedMapSlice: []NamedMap{
+		NamedMap{
+			"key2": "value2",
+		},
+		NamedMap{
+			"key3": "value3",
 		},
 	},
 }
 
 var deepNestString = `{` +
 	`"SliceMap":{` +
-	`"testSliceMap1":["0","1"]` +
+	`"testSliceMap":["0","1"]` +
 	`},` +
 	`"SliceMap1":{` +
-	`"testSliceMap2":[]` +
+	`"testSliceMap1":[]` +
+	`},` +
+	`"NamedSliceMap":{` +
+	`"testNamedSliceMap":["2","3"]` +
+	`},` +
+	`"NamedMapMap":{` +
+	`"testNamedMapMap":{"key1":"value1"}` +
 	`},` +
 	`"MapSlice":[` +
-	`{"testMapSlice1":"someValue"}` +
+	`{"testMapSlice":"someValue"}` +
+	`],` +
+	`"NamedSliceSlice":[` +
+	`["someValue1","someValue2"],` +
+	`["someValue3","someValue4"]` +
+	`],` +
+	`"NamedMapSlice":[` +
+	`{"key2":"value2"},` +
+	`{"key3":"value3"}` +
 	`]` +
 	`}`
 

--- a/tests/data.go
+++ b/tests/data.go
@@ -440,13 +440,14 @@ type NamedSlice []Str
 type NamedMap map[Str]Str
 
 type DeepNest struct {
-	SliceMap        map[Str][]Str
-	SliceMap1       map[Str][]Str
-	NamedSliceMap   map[Str]NamedSlice
-	NamedMapMap     map[Str]NamedMap
-	MapSlice        []map[Str]Str
-	NamedSliceSlice []NamedSlice
-	NamedMapSlice   []NamedMap
+	SliceMap         map[Str][]Str
+	SliceMap1        map[Str][]Str
+	NamedSliceMap    map[Str]NamedSlice
+	NamedMapMap      map[Str]NamedMap
+	MapSlice         []map[Str]Str
+	NamedSliceSlice  []NamedSlice
+	NamedMapSlice    []NamedMap
+	NamedStringSlice []NamedString
 }
 
 var deepNestValue = DeepNest{
@@ -493,6 +494,9 @@ var deepNestValue = DeepNest{
 			"key3": "value3",
 		},
 	},
+	NamedStringSlice: []NamedString{
+		"value4", "value5",
+	},
 }
 
 var deepNestString = `{` +
@@ -518,7 +522,8 @@ var deepNestString = `{` +
 	`"NamedMapSlice":[` +
 	`{"key2":"value2"},` +
 	`{"key3":"value3"}` +
-	`]` +
+	`],` +
+	`"NamedStringSlice":["value4","value5"]` +
 	`}`
 
 type RequiredOptionalStruct struct {


### PR DESCRIPTION
There is a bug with named types after #39 merge. Named types are replaced by underlying type so generated code has error with types.

See test cases for more details.