### PR TITLE
Follow standard encoding/json unmarshalling logic for pointers

### DIFF
--- a/gen/decoder.go
+++ b/gen/decoder.go
@@ -118,7 +118,9 @@ func (g *Generator) genTypeDecoderNoCheck(t reflect.Type, out string, tags field
 		fmt.Fprintln(g.out, ws+"  in.Skip()")
 		fmt.Fprintln(g.out, ws+"  "+out+" = nil")
 		fmt.Fprintln(g.out, ws+"} else {")
-		fmt.Fprintln(g.out, ws+"  "+out+" = new("+g.getType(t.Elem())+")")
+		fmt.Fprintln(g.out, ws+"  if ("+out+") == nil {")
+		fmt.Fprintln(g.out, ws+"    "+out+" = new("+g.getType(t.Elem())+")")
+		fmt.Fprintln(g.out, ws+"  }")
 
 		g.genTypeDecoder(t.Elem(), "*"+out, tags, indent+1)
 


### PR DESCRIPTION
From https://golang.org/pkg/encoding/json/#Unmarshal:

To unmarshal JSON into a pointer, Unmarshal first handles the case of the JSON being the JSON literal null. In that case, Unmarshal sets the pointer to nil. Otherwise, Unmarshal unmarshals the JSON into the value pointed at by the pointer. If the pointer is nil, Unmarshal allocates a new value for it to point to.