### PR TITLE
encoding/json compatibility with slices

### DIFF
--- a/gen/decoder.go
+++ b/gen/decoder.go
@@ -86,26 +86,42 @@ func (g *Generator) genTypeDecoderNoCheck(t reflect.Type, out string, tags field
 		tmpVar := g.uniqueVarName()
 		elem := t.Elem()
 
-		capacity := minSliceBytes / elem.Size()
-		if capacity == 0 {
-			capacity = 1
+		if elem.Kind() == reflect.Uint8 {
+			fmt.Fprintln(g.out, ws+"if in.IsNull() {")
+			fmt.Fprintln(g.out, ws+"  in.Skip()")
+			fmt.Fprintln(g.out, ws+"  "+out+" = nil")
+			fmt.Fprintln(g.out, ws+"} else {")
+			fmt.Fprintln(g.out, ws+"  "+out+" = in.Bytes()")
+			fmt.Fprintln(g.out, ws+"}")
+
+		} else {
+
+			capacity := minSliceBytes / elem.Size()
+			if capacity == 0 {
+				capacity = 1
+			}
+
+			fmt.Fprintln(g.out, ws+"if in.IsNull() {")
+			fmt.Fprintln(g.out, ws+"  in.Skip()")
+			fmt.Fprintln(g.out, ws+"  "+out+" = nil")
+			fmt.Fprintln(g.out, ws+"} else {")
+			fmt.Fprintln(g.out, ws+"  in.Delim('[')")
+			fmt.Fprintln(g.out, ws+"  if !in.IsDelim(']') {")
+			fmt.Fprintln(g.out, ws+"    "+out+" = make("+g.getType(t)+", 0, "+fmt.Sprint(capacity)+")")
+			fmt.Fprintln(g.out, ws+"  } else {")
+			fmt.Fprintln(g.out, ws+"    "+out+" = "+g.getType(t)+"{}")
+			fmt.Fprintln(g.out, ws+"  }")
+			fmt.Fprintln(g.out, ws+"  for !in.IsDelim(']') {")
+			fmt.Fprintln(g.out, ws+"    var "+tmpVar+" "+g.getType(elem))
+
+			g.genTypeDecoder(elem, tmpVar, tags, indent+2)
+
+			fmt.Fprintln(g.out, ws+"    "+out+" = append("+out+", "+tmpVar+")")
+			fmt.Fprintln(g.out, ws+"    in.WantComma()")
+			fmt.Fprintln(g.out, ws+"  }")
+			fmt.Fprintln(g.out, ws+"  in.Delim(']')")
+			fmt.Fprintln(g.out, ws+"}")
 		}
-
-		fmt.Fprintln(g.out, ws+"in.Delim('[')")
-		fmt.Fprintln(g.out, ws+"if !in.IsDelim(']') {")
-		fmt.Fprintln(g.out, ws+"  "+out+" = make("+g.getType(t)+", 0, "+fmt.Sprint(capacity)+")")
-		fmt.Fprintln(g.out, ws+"} else {")
-		fmt.Fprintln(g.out, ws+"  "+out+" = nil")
-		fmt.Fprintln(g.out, ws+"}")
-		fmt.Fprintln(g.out, ws+"for !in.IsDelim(']') {")
-		fmt.Fprintln(g.out, ws+"  var "+tmpVar+" "+g.getType(elem))
-
-		g.genTypeDecoder(elem, tmpVar, tags, indent+1)
-
-		fmt.Fprintln(g.out, ws+"  "+out+" = append("+out+", "+tmpVar+")")
-		fmt.Fprintln(g.out, ws+"  in.WantComma()")
-		fmt.Fprintln(g.out, ws+"}")
-		fmt.Fprintln(g.out, ws+"in.Delim(']')")
 
 	case reflect.Struct:
 		dec := g.getDecoderName(t)

--- a/gen/decoder.go
+++ b/gen/decoder.go
@@ -118,7 +118,7 @@ func (g *Generator) genTypeDecoderNoCheck(t reflect.Type, out string, tags field
 		fmt.Fprintln(g.out, ws+"  in.Skip()")
 		fmt.Fprintln(g.out, ws+"  "+out+" = nil")
 		fmt.Fprintln(g.out, ws+"} else {")
-		fmt.Fprintln(g.out, ws+"  if ("+out+") == nil {")
+		fmt.Fprintln(g.out, ws+"  if "+out+" == nil {")
 		fmt.Fprintln(g.out, ws+"    "+out+" = new("+g.getType(t.Elem())+")")
 		fmt.Fprintln(g.out, ws+"  }")
 

--- a/jlexer/lexer_test.go
+++ b/jlexer/lexer_test.go
@@ -1,6 +1,7 @@
 package jlexer
 
 import (
+	"bytes"
 	"reflect"
 	"testing"
 )
@@ -35,6 +36,34 @@ func TestString(t *testing.T) {
 			t.Errorf("[%d, %q] String() error: %v", i, test.toParse, err)
 		} else if err == nil && test.wantError {
 			t.Errorf("[%d, %q] String() ok; want error", i, test.toParse)
+		}
+	}
+}
+
+func TestBytes(t *testing.T) {
+	for i, test := range []struct {
+		toParse   string
+		want      string
+		wantError bool
+	}{
+		{toParse: `"c2ltcGxlIHN0cmluZw=="`, want: "simple string"},
+		{toParse: " \r\r\n\t  " + `"dGVzdA=="`, want: "test"},
+
+		{toParse: `5`, wantError: true},                     // not a JSON string
+		{toParse: `"foobar"`, wantError: true},              // not base64 encoded
+		{toParse: `"c2ltcGxlIHN0cmluZw="`, wantError: true}, // invalid base64 padding
+	} {
+		l := Lexer{Data: []byte(test.toParse)}
+
+		got := l.Bytes()
+		if bytes.Compare(got, []byte(test.want)) != 0 {
+			t.Errorf("[%d, %q] Bytes() = %v; want: %v", i, test.toParse, got, []byte(test.want))
+		}
+		err := l.Error()
+		if err != nil && !test.wantError {
+			t.Errorf("[%d, %q] Bytes() error: %v", i, test.toParse, err)
+		} else if err == nil && test.wantError {
+			t.Errorf("[%d, %q] Bytes() ok; want error", i, test.toParse)
 		}
 	}
 }

--- a/jwriter/writer.go
+++ b/jwriter/writer.go
@@ -2,6 +2,7 @@
 package jwriter
 
 import (
+	"encoding/base64"
 	"io"
 	"strconv"
 	"unicode/utf8"
@@ -57,6 +58,19 @@ func (w *Writer) Raw(data []byte, err error) {
 	default:
 		w.RawString("null")
 	}
+}
+
+// Base64Bytes appends data to the buffer after base64 encoding it
+func (w *Writer) Base64Bytes(data []byte) {
+	if data == nil {
+		w.Buffer.AppendString("null")
+		return
+	}
+	w.Buffer.AppendByte('"')
+	dst := make([]byte, base64.StdEncoding.EncodedLen(len(data)))
+	base64.StdEncoding.Encode(dst, data)
+	w.Buffer.AppendBytes(dst)
+	w.Buffer.AppendByte('"')
 }
 
 func (w *Writer) Uint8(n uint8) {

--- a/tests/basic_test.go
+++ b/tests/basic_test.go
@@ -30,6 +30,7 @@ var testCases = []struct {
 	{&stdMarshalerValue, stdMarshalerString},
 	{&unexportedStructValue, unexportedStructString},
 	{&excludedFieldValue, excludedFieldString},
+	{&sliceValue, sliceString},
 	{&mapsValue, mapsString},
 	{&deepNestValue, deepNestString},
 	{&IntsValue, IntsString},

--- a/tests/data.go
+++ b/tests/data.go
@@ -296,10 +296,10 @@ var structsString = "{" +
 	`"SubNil":null,` +
 
 	`"SubSlice":[{"Value":"s1","Value2":""},{"Value":"s2","Value2":""}],` +
-	`"SubSliceNil":[],` +
+	`"SubSliceNil":null,` +
 
 	`"SubPtrSlice":[{"Value":"p1","Value2":""},{"Value":"p2","Value2":""}],` +
-	`"SubPtrSliceNil":[],` +
+	`"SubPtrSliceNil":null,` +
 
 	`"SubA1":{"Value":"test3","Value2":"v3"},` +
 	`"SubA2":{"Value":"test4","Value2":"v4"},` +
@@ -418,6 +418,33 @@ var excludedFieldValue = ExcludedField{
 }
 var excludedFieldString = `{"process":true}`
 
+type Slices struct {
+	ByteSlice      []byte
+	EmptyByteSlice []byte
+	NilByteSlice   []byte
+	IntSlice       []int
+	EmptyIntSlice  []int
+	NilIntSlice    []int
+}
+
+var sliceValue = Slices{
+	ByteSlice:      []byte("abc"),
+	EmptyByteSlice: []byte{},
+	NilByteSlice:   []byte(nil),
+	IntSlice:       []int{1, 2, 3, 4, 5},
+	EmptyIntSlice:  []int{},
+	NilIntSlice:    []int(nil),
+}
+
+var sliceString = `{` +
+	`"ByteSlice":"YWJj",` +
+	`"EmptyByteSlice":"",` +
+	`"NilByteSlice":null,` +
+	`"IntSlice":[1,2,3,4,5],` +
+	`"EmptyIntSlice":[],` +
+	`"NilIntSlice":null` +
+	`}`
+
 type Str string
 
 type Maps struct {
@@ -448,6 +475,7 @@ type NamedMap map[Str]Str
 type DeepNest struct {
 	SliceMap         map[Str][]Str
 	SliceMap1        map[Str][]Str
+	SliceMap2        map[Str][]Str
 	NamedSliceMap    map[Str]NamedSlice
 	NamedMapMap      map[Str]NamedMap
 	MapSlice         []map[Str]Str
@@ -464,7 +492,10 @@ var deepNestValue = DeepNest{
 		},
 	},
 	SliceMap1: map[Str][]Str{
-		"testSliceMap1": nil,
+		"testSliceMap1": []Str(nil),
+	},
+	SliceMap2: map[Str][]Str{
+		"testSliceMap2": []Str{},
 	},
 	NamedSliceMap: map[Str]NamedSlice{
 		"testNamedSliceMap": NamedSlice{
@@ -510,7 +541,10 @@ var deepNestString = `{` +
 	`"testSliceMap":["0","1"]` +
 	`},` +
 	`"SliceMap1":{` +
-	`"testSliceMap1":[]` +
+	`"testSliceMap1":null` +
+	`},` +
+	`"SliceMap2":{` +
+	`"testSliceMap2":[]` +
 	`},` +
 	`"NamedSliceMap":{` +
 	`"testNamedSliceMap":["2","3"]` +


### PR DESCRIPTION
From encoding/json regarding Marshalling:
Array and slice values encode as JSON arrays, except that []byte encodes as a base64-encoded string, and a nil slice encodes as the null JSON value.

Also, empty slices encode differently than nil slices: the former encodes as an empty JSON array, but the latter encodes as JSON null. See the following goplay demo with encoding/json: https://play.golang.org/p/Z_YE5PHS3g