### PR TITLE
SkipRecursive fails while having double slashes at the end of the string

### DIFF
--- a/jlexer/lexer.go
+++ b/jlexer/lexer.go
@@ -506,7 +506,7 @@ func (r *Lexer) SkipRecursive() {
 				return
 			}
 		case c == '\\' && inQuotes:
-			wasEscape = true
+			wasEscape = !wasEscape
 			continue
 		case c == '"' && inQuotes:
 			inQuotes = wasEscape
@@ -516,8 +516,11 @@ func (r *Lexer) SkipRecursive() {
 		wasEscape = false
 	}
 	r.pos = len(r.Data)
-	r.err = io.EOF
-}
+	r.err = &LexerError{
+		Reason: "EOF reached while skipping array/object or token",
+		Offset: r.pos,
+		Data: string(r.Data[r.pos:]),
+	}}
 
 // Raw fetches the next item recursively as a data slice
 func (r *Lexer) Raw() []byte {

--- a/jlexer/lexer_test.go
+++ b/jlexer/lexer_test.go
@@ -157,6 +157,9 @@ func TestSkipRecursive(t *testing.T) {
 		{toParse: `{"a\"}":1}, 4`, left: ", 4"},
 		{toParse: `{"a{":1}, 4`, left: ", 4"},
 		{toParse: `{"a\"{":1}, 4`, left: ", 4"},
+
+		// object with double slashes at the end of string
+		{toParse: `{"a":"hey\\"}, 4`, left: ", 4"},
 	} {
 		l := Lexer{Data: []byte(test.toParse)}
 


### PR DESCRIPTION
Fixing EOF error to appear while having double slashes at the end of the string. 

This bug resulted in an error while trying to Unmarshal an object that has some attributes with custom UnmarshalJSON method.