### PR TITLE
Empty map is unmarshaled to nil

### DIFF
--- a/gen/decoder.go
+++ b/gen/decoder.go
@@ -189,11 +189,7 @@ func (g *Generator) genTypeDecoderNoCheck(t reflect.Type, out string, tags field
 		fmt.Fprintln(g.out, ws+"  in.Skip()")
 		fmt.Fprintln(g.out, ws+"} else {")
 		fmt.Fprintln(g.out, ws+"  in.Delim('{')")
-		fmt.Fprintln(g.out, ws+"  if !in.IsDelim('}') {")
 		fmt.Fprintln(g.out, ws+"  "+out+" = make("+g.getType(t)+")")
-		fmt.Fprintln(g.out, ws+"  } else {")
-		fmt.Fprintln(g.out, ws+"  "+out+" = nil")
-		fmt.Fprintln(g.out, ws+"  }")
 
 		fmt.Fprintln(g.out, ws+"  for !in.IsDelim('}') {")
 		fmt.Fprintln(g.out, ws+"    key := "+g.getType(t.Key())+"(in.String())")

--- a/tests/data.go
+++ b/tests/data.go
@@ -491,6 +491,7 @@ type Maps struct {
 	Map          map[string]string
 	InterfaceMap map[string]interface{}
 	NilMap       map[string]string
+	EmptyMap     map[string]string
 
 	CustomMap map[Str]Str
 }
@@ -498,6 +499,7 @@ type Maps struct {
 var mapsValue = Maps{
 	Map:          map[string]string{"A": "b"}, // only one item since map iteration is randomized
 	InterfaceMap: map[string]interface{}{"G": float64(1)},
+	EmptyMap:     map[string]string{},
 
 	CustomMap: map[Str]Str{"c": "d"},
 }
@@ -506,6 +508,7 @@ var mapsString = `{` +
 	`"Map":{"A":"b"},` +
 	`"InterfaceMap":{"G":1},` +
 	`"NilMap":null,` +
+	`"EmptyMap":{},` +
 	`"CustomMap":{"c":"d"}` +
 	`}`
 


### PR DESCRIPTION
When I trying to unmarshal JSON literal "{Foo: 1, Bar: {}}" to some struct like this using easyjson,

type FooBar struct {
  Foo int
  Bar map[string]int
}

The result of FooBar.Bar becomes "nil", instead of empty map.
IMHO This is unexpected behaviour, because empty map and "nil" map is different. "nil" map should be marshaled to "null" in JSON, empty map should be marshaled to "{}" in JSON, and vice versa.

Standard encoding/json works as expected.
