### PR TITLE
modify Lexer.Delim to avoid covert []byte to string

### DIFF
--- a/jlexer/lexer.go
+++ b/jlexer/lexer.go
@@ -425,13 +425,19 @@ func (r *Lexer) errInvalidToken(expected string) {
 	}
 }
 
+func (r *Lexer) errInvalidToken2(c byte) {
+	if r.err == nil {
+		r.errInvalidToken(string([]byte{c}))
+	}
+}
+
 // Delim consumes a token and verifies that it is the given delimiter.
 func (r *Lexer) Delim(c byte) {
 	if r.token.kind == tokenUndef && r.Ok() {
 		r.fetchToken()
 	}
 	if !r.Ok() || r.token.delimValue != c {
-		r.errInvalidToken(string([]byte{c}))
+		r.errInvalidToken2(c)
 	}
 	r.consume()
 }


### PR DESCRIPTION
Hi, Thank you for creating easyjson, it's so fast. 
But when I profiling the generated code, I found Lexer.Delim() call r.errInvalidToken convert byte to slice of byte and then covert it to string.

I just modify Lexer, add errInvalidToken2(c byte) just be used for Delim.
