### PR TITLE
Add support for array types

### DIFF
--- a/gen/decoder.go
+++ b/gen/decoder.go
@@ -143,11 +143,15 @@ func (g *Generator) genTypeDecoderNoCheck(t reflect.Type, out string, tags field
 			fmt.Fprintln(g.out, ws+"} else {")
 			fmt.Fprintln(g.out, ws+"  in.Delim('[')")
 			fmt.Fprintln(g.out, ws+"  "+iterVar+" := 0")
-			fmt.Fprintln(g.out, ws+"  for !in.IsDelim(']') && "+iterVar+" < "+fmt.Sprint(length)+" {")
+			fmt.Fprintln(g.out, ws+"  for !in.IsDelim(']') {")
+			fmt.Fprintln(g.out, ws+"    if "+iterVar+" < "+fmt.Sprint(length)+" {")
 
-			g.genTypeDecoder(elem, out+"["+iterVar+"]", tags, indent+2)
+			g.genTypeDecoder(elem, out+"["+iterVar+"]", tags, indent+3)
 
-			fmt.Fprintln(g.out, ws+"    "+iterVar+"++")
+			fmt.Fprintln(g.out, ws+"      "+iterVar+"++")
+			fmt.Fprintln(g.out, ws+"    } else {")
+			fmt.Fprintln(g.out, ws+"      in.SkipRecursive()")
+			fmt.Fprintln(g.out, ws+"    }")
 			fmt.Fprintln(g.out, ws+"    in.WantComma()")
 			fmt.Fprintln(g.out, ws+"  }")
 			fmt.Fprintln(g.out, ws+"  in.Delim(']')")

--- a/gen/decoder.go
+++ b/gen/decoder.go
@@ -124,7 +124,6 @@ func (g *Generator) genTypeDecoderNoCheck(t reflect.Type, out string, tags field
 		}
 
 	case reflect.Array:
-		tmpVar := g.uniqueVarName()
 		iterVar := g.uniqueVarName()
 		elem := t.Elem()
 
@@ -145,11 +144,9 @@ func (g *Generator) genTypeDecoderNoCheck(t reflect.Type, out string, tags field
 			fmt.Fprintln(g.out, ws+"  in.Delim('[')")
 			fmt.Fprintln(g.out, ws+"  "+iterVar+" := 0")
 			fmt.Fprintln(g.out, ws+"  for !in.IsDelim(']') && "+iterVar+" < "+fmt.Sprint(length)+" {")
-			fmt.Fprintln(g.out, ws+"    var "+tmpVar+" "+g.getType(elem))
 
-			g.genTypeDecoder(elem, tmpVar, tags, indent+2)
+			g.genTypeDecoder(elem, out+"["+iterVar+"]", tags, indent+2)
 
-			fmt.Fprintln(g.out, ws+"    "+out+"["+iterVar+"] = "+tmpVar)
 			fmt.Fprintln(g.out, ws+"    "+iterVar+"++")
 			fmt.Fprintln(g.out, ws+"    in.WantComma()")
 			fmt.Fprintln(g.out, ws+"  }")

--- a/gen/encoder.go
+++ b/gen/encoder.go
@@ -214,7 +214,7 @@ func (g *Generator) notEmptyCheck(t reflect.Type, v string) string {
 	}
 
 	switch t.Kind() {
-	case reflect.Slice, reflect.Map: // note: Array types don't have a useful empty value
+	case reflect.Slice, reflect.Map:
 		return "len(" + v + ") != 0"
 	case reflect.Interface, reflect.Ptr:
 		return v + " != nil"
@@ -229,6 +229,7 @@ func (g *Generator) notEmptyCheck(t reflect.Type, v string) string {
 		return v + " != 0"
 
 	default:
+		// note: Array types don't have a useful empty value
 		return "true"
 	}
 }

--- a/gen/encoder.go
+++ b/gen/encoder.go
@@ -140,18 +140,17 @@ func (g *Generator) genTypeEncoderNoCheck(t reflect.Type, in string, tags fieldT
 	case reflect.Array:
 		elem := t.Elem()
 		iVar := g.uniqueVarName()
-		vVar := g.uniqueVarName()
 
 		if t.Elem().Kind() == reflect.Uint8 {
 			fmt.Fprintln(g.out, ws+"out.Base64Bytes("+in+"[:])")
 		} else {
 			fmt.Fprintln(g.out, ws+"out.RawByte('[')")
-			fmt.Fprintln(g.out, ws+"for "+iVar+", "+vVar+" := range "+in+" {")
+			fmt.Fprintln(g.out, ws+"for "+iVar+" := range "+in+" {")
 			fmt.Fprintln(g.out, ws+"  if "+iVar+" > 0 {")
 			fmt.Fprintln(g.out, ws+"    out.RawByte(',')")
 			fmt.Fprintln(g.out, ws+"  }")
 
-			g.genTypeEncoder(elem, vVar, tags, indent+1)
+			g.genTypeEncoder(elem, in+"["+iVar+"]", tags, indent+1)
 
 			fmt.Fprintln(g.out, ws+"}")
 			fmt.Fprintln(g.out, ws+"out.RawByte(']')")

--- a/gen/generator.go
+++ b/gen/generator.go
@@ -8,6 +8,7 @@ import (
 	"path"
 	"reflect"
 	"sort"
+	"strconv"
 	"strings"
 	"unicode"
 )
@@ -233,6 +234,8 @@ func (g *Generator) getType(t reflect.Type) string {
 			return "*" + g.getType(t.Elem())
 		case reflect.Slice:
 			return "[]" + g.getType(t.Elem())
+		case reflect.Array:
+			return "[" + strconv.Itoa(t.Len()) + "]" + g.getType(t.Elem())
 		case reflect.Map:
 			return "map[" + g.getType(t.Key()) + "]" + g.getType(t.Elem())
 		}

--- a/tests/basic_test.go
+++ b/tests/basic_test.go
@@ -31,6 +31,7 @@ var testCases = []struct {
 	{&unexportedStructValue, unexportedStructString},
 	{&excludedFieldValue, excludedFieldString},
 	{&sliceValue, sliceString},
+	{&arrayValue, arrayString},
 	{&mapsValue, mapsString},
 	{&deepNestValue, deepNestString},
 	{&IntsValue, IntsString},

--- a/tests/data.go
+++ b/tests/data.go
@@ -445,6 +445,27 @@ var sliceString = `{` +
 	`"NilIntSlice":null` +
 	`}`
 
+type Arrays struct {
+	ByteArray      [3]byte
+	EmptyByteArray [0]byte
+	IntArray       [5]int
+	EmptyIntArray  [0]int
+}
+
+var arrayValue = Arrays{
+	ByteArray:      [3]byte{'a', 'b', 'c'},
+	EmptyByteArray: [0]byte{},
+	IntArray:       [5]int{1, 2, 3, 4, 5},
+	EmptyIntArray:  [0]int{},
+}
+
+var arrayString = `{` +
+	`"ByteArray":"YWJj",` +
+	`"EmptyByteArray":"",` +
+	`"IntArray":[1,2,3,4,5],` +
+	`"EmptyIntArray":[]` +
+	`}`
+
 type Str string
 
 type Maps struct {


### PR DESCRIPTION
Arrays are useful to decode into to keep the allocations down
and thus the gc pressure low.

The code allows the json to contain truncated arrays without
raising an error, same as standard encoding/json. However excess
elements in the json is an error.