### PR TITLE
Use MarshalJSON() instead of json.Marshal() for interface type if it implements json.Marshaler

### DIFF
--- a/gen/encoder.go
+++ b/gen/encoder.go
@@ -180,7 +180,11 @@ func (g *Generator) genTypeEncoderNoCheck(t reflect.Type, in string, tags fieldT
 		if t.NumMethod() != 0 {
 			return fmt.Errorf("interface type %v not supported: only interface{} is allowed", t)
 		}
-		fmt.Fprintln(g.out, ws+"out.Raw(json.Marshal("+in+"))")
+		fmt.Fprintln(g.out, ws+"if m, ok := "+in+".(json.Marshaler); ok {")
+		fmt.Fprintln(g.out, ws+"  out.Raw(m.MarshalJSON())")
+		fmt.Fprintln(g.out, ws+"} else {")
+		fmt.Fprintln(g.out, ws+"  out.Raw(json.Marshal("+in+"))")
+		fmt.Fprintln(g.out, ws+"}")
 
 	default:
 		return fmt.Errorf("don't know how to encode %v", t)


### PR DESCRIPTION
Now interface fields in struct marshal via json.Marshal, it's very slow in case of this field implements easyjson marshaler and can marshal via MarshalJSON(). So we can just check if it field json.Marshaler and use MarshalJSON() instead of json.Marshal, and we get the best performance.