### PR TITLE
Add name strategy based on protobuf tags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ generate: root build
 	.root/bin/easyjson -all .root/src/$(PKG)/tests/nothing.go
 	.root/bin/easyjson -snake_case .root/src/$(PKG)/tests/snake.go
 	.root/bin/easyjson -omit_empty .root/src/$(PKG)/tests/omitempty.go
+	.root/bin/easyjson -field_namer=protobuf .root/src/$(PKG)/tests/protobuf.go
 	.root/bin/easyjson -build_tags=use_easyjson .root/src/$(PKG)/benchmark/data.go
 
 test: generate root

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -22,7 +22,7 @@ type Generator struct {
 	Types            []string
 
 	NoStdMarshalers bool
-	SnakeCase       bool
+	FieldNamer      string
 	OmitEmpty       bool
 
 	OutName   string
@@ -105,9 +105,8 @@ func (g *Generator) writeMain() (path string, err error) {
 	if g.BuildTags != "" {
 		fmt.Fprintf(f, "  g.SetBuildTags(%q)\n", g.BuildTags)
 	}
-	if g.SnakeCase {
-		fmt.Fprintln(f, "  g.UseSnakeCase()")
-	}
+	fmt.Fprintf(f, "  fieldNamer := gen.FieldNamers[\"%s\"]\n", g.FieldNamer)
+	fmt.Fprintln(f, "  g.SetFieldNamer(fieldNamer)")
 	if g.OmitEmpty {
 		fmt.Fprintln(f, "  g.OmitEmpty()")
 	}

--- a/tests/protobuf.go
+++ b/tests/protobuf.go
@@ -1,0 +1,10 @@
+package tests
+
+//easyjson:json
+type ProtobufStruct struct {
+	JsonTagOnlyField bool   `json:"json_tag_only_field"`
+	ProtobufField    string `protobuf:"bytes,4,opt,name=protobuf_field,json=protobufField" json:"protobuf_field,omitempty"`
+}
+
+var protobufStructValue = ProtobufStruct{ProtobufField: "some value"}
+var protobufStructString = `{"json_tag_only_field":false,"protobufField":"some value"}`


### PR DESCRIPTION
Hi there!
What do you think about adding another strategy for naming keys in json based not on `json` struct tag, but extracting from `protobuf`. Idea is to generate fast (un)marshaller based on `gogo`/`protobuf` compiler output, thus having best of both worlds - fast and succinct internal format and fast user/browser friendly one?

As a proof of concept I implemented this by adding a new flag `-field_namer`, which can be one of `default, snake_case, protobuf`. Thus we don't break existing users (if they don't mix old and new flags).
