### PR TITLE
Remove vendor path from imports. PkgPath() workaround.

### DIFF
--- a/gen/generator.go
+++ b/gen/generator.go
@@ -199,8 +199,18 @@ func (g *Generator) Run(out io.Writer) error {
 	return err
 }
 
+// fixes vendored paths
+func fixPkgPathVendoring(pkgPath string) string {
+	const vendor = "/vendor/"
+	if i := strings.LastIndex(pkgPath, vendor); i != -1 {
+		return pkgPath[i+len(vendor):]
+	}
+	return pkgPath
+}
+
 // pkgAlias creates and returns and import alias for a given package.
 func (g *Generator) pkgAlias(pkgPath string) string {
+	pkgPath = fixPkgPathVendoring(pkgPath)
 	if alias := g.imports[pkgPath]; alias != "" {
 		return alias
 	}

--- a/gen/generator_test.go
+++ b/gen/generator_test.go
@@ -47,3 +47,19 @@ func TestJoinFunctionNameParts(t *testing.T) {
 		}
 	}
 }
+
+func TestFixVendorPath(t *testing.T) {
+	for i, test := range []struct {
+		In, Out string
+	}{
+		{"", ""},
+		{"time", "time"},
+		{"project/vendor/subpackage", "subpackage"},
+	} {
+		got := fixPkgPathVendoring(test.In)
+		if got != test.Out {
+			t.Errorf("[%d] fixPkgPathVendoring(%s) = %s; want %s", i, test.In, got, test.Out)
+		}
+	}
+
+}


### PR DESCRIPTION
According to https://github.com/golang/go/issues/12739
and to https://github.com/mailru/easyjson/issues/29