### PR TITLE
Allow interface{} fields to be marshaled using easyjson.Marshaler

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ generate: root build
 	.root/bin/easyjson -snake_case .root/src/$(PKG)/tests/snake.go
 	.root/bin/easyjson -omit_empty .root/src/$(PKG)/tests/omitempty.go
 	.root/bin/easyjson -build_tags=use_easyjson .root/src/$(PKG)/benchmark/data.go
+	.root/bin/easyjson .root/src/$(PKG)/tests/nested_easy.go
 
 test: generate root
 	go test \

--- a/gen/encoder.go
+++ b/gen/encoder.go
@@ -199,7 +199,9 @@ func (g *Generator) genTypeEncoderNoCheck(t reflect.Type, in string, tags fieldT
 		if t.NumMethod() != 0 {
 			return fmt.Errorf("interface type %v not supported: only interface{} is allowed", t)
 		}
-		fmt.Fprintln(g.out, ws+"if m, ok := "+in+".(json.Marshaler); ok {")
+		fmt.Fprintln(g.out, ws+"if m, ok := "+in+".(easyjson.Marshaler); ok {")
+		fmt.Fprintln(g.out, ws+"  m.MarshalEasyJSON(out)")
+		fmt.Fprintln(g.out, ws+"} else if m, ok := "+in+".(json.Marshaler); ok {")
 		fmt.Fprintln(g.out, ws+"  out.Raw(m.MarshalJSON())")
 		fmt.Fprintln(g.out, ws+"} else {")
 		fmt.Fprintln(g.out, ws+"  out.Raw(json.Marshal("+in+"))")

--- a/gen/generator.go
+++ b/gen/generator.go
@@ -15,6 +15,7 @@ import (
 
 const pkgWriter = "github.com/mailru/easyjson/jwriter"
 const pkgLexer = "github.com/mailru/easyjson/jlexer"
+const pkgEasyjson = "github.com/mailru/easyjson"
 
 // FieldNamer defines a policy for generating names for struct fields.
 type FieldNamer interface {
@@ -59,6 +60,7 @@ func NewGenerator(filename string) *Generator {
 		imports: map[string]string{
 			pkgWriter:       "jwriter",
 			pkgLexer:        "jlexer",
+			pkgEasyjson:      "easyjson",
 			"encoding/json": "json",
 		},
 		fieldNamer:    DefaultFieldNamer{},
@@ -159,9 +161,10 @@ func (g *Generator) printHeader() {
 	fmt.Println("")
 	fmt.Println("// suppress unused package warning")
 	fmt.Println("var (")
-	fmt.Println("   _ = json.RawMessage{}")
-	fmt.Println("   _ = jlexer.Lexer{}")
-	fmt.Println("   _ = jwriter.Writer{}")
+	fmt.Println("   _ *json.RawMessage")
+	fmt.Println("   _ *jlexer.Lexer")
+	fmt.Println("   _ *jwriter.Writer")
+	fmt.Println("   _ easyjson.Marshaler")
 	fmt.Println(")")
 
 	fmt.Println()

--- a/tests/basic_test.go
+++ b/tests/basic_test.go
@@ -156,3 +156,26 @@ func TestUnderflowArray(t *testing.T) {
 		t.Errorf("Unmarshal(%v) = %+v; want %+v", arrayUnderflowString, a, arrayUnderflowValue)
 	}
 }
+
+func TestNestedEasyJsonMarshal(t *testing.T) {
+	n := map[string]*NestedEasyMarshaler{
+		"Value":  {},
+		"Slice1": {},
+		"Slice2": {},
+		"Map1":   {},
+		"Map2":   {},
+	}
+
+	ni := NestedInterfaces{
+		Value: n["Value"],
+		Slice: []interface{}{n["Slice1"], n["Slice2"]},
+		Map:   map[string]interface{}{"1": n["Map1"], "2": n["Map2"]},
+	}
+	easyjson.Marshal(ni)
+
+	for k, v := range n {
+		if !v.EasilyMarshaled {
+			t.Errorf("Nested interface %s wasn't easily marshaled", k)
+		}
+	}
+}

--- a/tests/nested_easy.go
+++ b/tests/nested_easy.go
@@ -19,5 +19,7 @@ type NestedEasyMarshaler struct {
 var _ easyjson.Marshaler = &NestedEasyMarshaler{}
 
 func (i *NestedEasyMarshaler) MarshalEasyJSON(w *jwriter.Writer) {
+	// We use this method only to indicate that easyjson.Marshaler
+	// interface was really used while encoding.
 	i.EasilyMarshaled = true
 }

--- a/tests/nested_easy.go
+++ b/tests/nested_easy.go
@@ -1,0 +1,23 @@
+package tests
+
+import (
+	"github.com/mailru/easyjson"
+	"github.com/mailru/easyjson/jwriter"
+)
+
+//easyjson:json
+type NestedInterfaces struct {
+	Value interface{}
+	Slice []interface{}
+	Map   map[string]interface{}
+}
+
+type NestedEasyMarshaler struct {
+	EasilyMarshaled bool
+}
+
+var _ easyjson.Marshaler = &NestedEasyMarshaler{}
+
+func (i *NestedEasyMarshaler) MarshalEasyJSON(w *jwriter.Writer) {
+	i.EasilyMarshaled = true
+}


### PR DESCRIPTION
Suppose we have the following struct:

```
type Struct struct {
  A int
  B string
  C interface{}
}
```

The code generated for the C field is something like:

```
if m, ok := C.(json.Marshaler); ok {
    out.Raw(m.MarshalJSON())
} else {
    out.Raw(json.Marshal(C))
}

```

Even if we generate std marshalers it will be slow. So let's add another cast to easyjson.Marshaler interface and use it for marshalling if supported. 

```
if m, ok := C.(easyjson.Marshaler); ok {
    m.MarshalEasyJSON(out)        
} else if m, ok := C.(json.Marshaler); ok {
    out.Raw(m.MarshalJSON())
} else {
    out.Raw(json.Marshal(C))
}
```
