### PR TITLE
Fix unmarshaling struct with interface field which is a pointer to another struct

### DIFF
--- a/gen/decoder.go
+++ b/gen/decoder.go
@@ -212,8 +212,13 @@ func (g *Generator) genTypeDecoderNoCheck(t reflect.Type, out string, tags field
 		if t.NumMethod() != 0 {
 			return fmt.Errorf("interface type %v not supported: only interface{} is allowed", t)
 		}
-		fmt.Fprintln(g.out, ws+out+" = in.Interface()")
-
+		fmt.Fprintln(g.out, ws+"if m, ok := "+out+".(easyjson.Unmarshaler); ok {")
+		fmt.Fprintln(g.out, ws+"m.UnmarshalEasyJSON(in)")
+		fmt.Fprintln(g.out, ws+"} else if m, ok := "+out+".(json.Unmarshaler); ok {")
+		fmt.Fprintln(g.out, ws+"m.UnmarshalJSON(in.Raw())")
+		fmt.Fprintln(g.out, ws+"} else {")
+		fmt.Fprintln(g.out, ws+"  "+out+" = in.Interface()")
+		fmt.Fprintln(g.out, ws+"}")
 	default:
 		return fmt.Errorf("don't know how to decode %v", t)
 	}

--- a/gen/generator.go
+++ b/gen/generator.go
@@ -15,7 +15,7 @@ import (
 
 const pkgWriter = "github.com/mailru/easyjson/jwriter"
 const pkgLexer = "github.com/mailru/easyjson/jlexer"
-const pkgEasyJson = "github.com/mailru/easyjson"
+const pkgEasyJSON = "github.com/mailru/easyjson"
 
 // FieldNamer defines a policy for generating names for struct fields.
 type FieldNamer interface {
@@ -60,7 +60,7 @@ func NewGenerator(filename string) *Generator {
 		imports: map[string]string{
 			pkgWriter:       "jwriter",
 			pkgLexer:        "jlexer",
-			pkgEasyJson:     "easyjson",
+			pkgEasyJSON:     "easyjson",
 			"encoding/json": "json",
 		},
 		fieldNamer:    DefaultFieldNamer{},

--- a/gen/generator.go
+++ b/gen/generator.go
@@ -15,6 +15,7 @@ import (
 
 const pkgWriter = "github.com/mailru/easyjson/jwriter"
 const pkgLexer = "github.com/mailru/easyjson/jlexer"
+const pkgEasyJson = "github.com/mailru/easyjson"
 
 // FieldNamer defines a policy for generating names for struct fields.
 type FieldNamer interface {
@@ -59,6 +60,7 @@ func NewGenerator(filename string) *Generator {
 		imports: map[string]string{
 			pkgWriter:       "jwriter",
 			pkgLexer:        "jlexer",
+			pkgEasyJson:     "easyjson",
 			"encoding/json": "json",
 		},
 		fieldNamer:    DefaultFieldNamer{},
@@ -162,6 +164,7 @@ func (g *Generator) printHeader() {
 	fmt.Println("   _ = json.RawMessage{}")
 	fmt.Println("   _ = jlexer.Lexer{}")
 	fmt.Println("   _ = jwriter.Writer{}")
+	fmt.Println("   _ easyjson.Marshaler")
 	fmt.Println(")")
 
 	fmt.Println()

--- a/tests/basic_test.go
+++ b/tests/basic_test.go
@@ -156,3 +156,15 @@ func TestUnderflowArray(t *testing.T) {
 		t.Errorf("Unmarshal(%v) = %+v; want %+v", arrayUnderflowString, a, arrayUnderflowValue)
 	}
 }
+
+func TestUnmarshalStructWithEmbeddedPtrStruct(t *testing.T) {
+	var s = StructWithInterface{Field2: &EmbeddedStruct{}}
+	var err error
+	err = easyjson.Unmarshal([]byte(structWithInterfaceString), &s)
+	if err != nil {
+		t.Errorf("easyjson.Unmarshal() error: %v", err)
+	}
+	if !reflect.DeepEqual(s, structWithInterfaceValueFilled) {
+		t.Errorf("easyjson.Unmarshal() = %#v; want %#v", s, structWithInterfaceValueFilled)
+	}
+}

--- a/tests/data.go
+++ b/tests/data.go
@@ -624,3 +624,17 @@ type RequiredOptionalStruct struct {
 	FirstName string `json:"first_name,required"`
 	Lastname  string `json:"last_name"`
 }
+
+type StructWithInterface struct {
+	Field1 int         `json:"f1"`
+	Field2 interface{} `json:"f2"`
+	Field3 string      `json:"f3"`
+}
+
+type EmbeddedStruct struct {
+	Field1 int    `json:"f1"`
+	Field2 string `json:"f2"`
+}
+
+var structWithInterfaceString = `{"f1":1,"f2":{"f1":11,"f2":"22"},"f3":"3"}`
+var structWithInterfaceValueFilled = StructWithInterface{1, &EmbeddedStruct{11, "22"}, "3"}


### PR DESCRIPTION
This pull request fixes a bug connected with unmarshaling struct which contains interface field, where interface is a pointer to another struct. Instead of filled embedded struct we get `map[string]interface{}`. See `TestUnmarshalStructWithEmbeddedPtrStruct` for example.
