### PR TITLE
Add OptionWriter interface

### DIFF
--- a/gen/decoder.go
+++ b/gen/decoder.go
@@ -358,6 +358,9 @@ func (g *Generator) genStructDecoder(t reflect.Type) error {
 		return fmt.Errorf("cannot generate encoder/decoder for %v, not a struct type", t)
 	}
 
+	optionWriterIface := reflect.TypeOf((*easyjson.OptionWriter)(nil)).Elem()
+	var optWriterImplemented bool = reflect.PtrTo(t).Implements(optionWriterIface)
+
 	fname := g.getDecoderName(t)
 	typ := g.getType(t)
 
@@ -367,6 +370,9 @@ func (g *Generator) genStructDecoder(t reflect.Type) error {
 	fmt.Fprintln(g.out, "    if isTopLevel {")
 	fmt.Fprintln(g.out, "      in.Consumed()")
 	fmt.Fprintln(g.out, "    }")
+	if optWriterImplemented {
+		fmt.Fprintln(g.out, "    out.SetDefined(false)")
+	}
 	fmt.Fprintln(g.out, "    in.Skip()")
 	fmt.Fprintln(g.out, "    return")
 	fmt.Fprintln(g.out, "  }")
@@ -418,6 +424,10 @@ func (g *Generator) genStructDecoder(t reflect.Type) error {
 
 	for _, f := range fs {
 		g.genRequiredFieldCheck(t, f)
+	}
+
+	if optWriterImplemented {
+		fmt.Fprintln(g.out, "out.SetDefined(true)")
 	}
 
 	fmt.Fprintln(g.out, "}")

--- a/helpers.go
+++ b/helpers.go
@@ -26,6 +26,12 @@ type Optional interface {
 	IsDefined() bool
 }
 
+// OptionWriter is the encoder analogy of the Optional interface; it defines a
+// setter method that called when unmarshalling struct fields.
+type OptionWriter interface {
+	SetDefined(defined bool)
+}
+
 // Marshal returns data as a single byte slice. Method is suboptimal as the data is likely to be copied
 // from a chain of smaller chunks.
 func Marshal(v Marshaler) ([]byte, error) {

--- a/tests/data.go
+++ b/tests/data.go
@@ -634,3 +634,13 @@ type EncodingFlagsTestMap struct {
 type EncodingFlagsTestSlice struct {
 	F []string
 }
+
+type Definable struct {
+	A   string `json:"a"`
+	B   string `json:"b"`
+	Def bool   `json:"-"`
+}
+
+func (o *Definable) SetDefined(defined bool) {
+	o.Def = defined
+}

--- a/tests/required_test.go
+++ b/tests/required_test.go
@@ -1,8 +1,8 @@
 package tests
 
 import (
-	"testing"
 	"fmt"
+	"testing"
 )
 
 func TestRequiredField(t *testing.T) {
@@ -17,12 +17,32 @@ func TestRequiredField(t *testing.T) {
 		err := v.UnmarshalJSON([]byte(tc.json))
 		if tc.errorMessage == "" {
 			if err != nil {
-				t.Errorf("%s. UnmarshallJSON didn`t expect error: %v", tc.json, err)
+				t.Errorf("%s. UnmarshalJSON didn`t expect error: %v", tc.json, err)
 			}
 		} else {
 			if fmt.Sprintf("%v", err) != tc.errorMessage {
-				t.Errorf("%s. UnmarshallJSON expected error: %v. got: %v", tc.json, tc.errorMessage, err)
+				t.Errorf("%s. UnmarshalJSON expected error: %v. got: %v", tc.json, tc.errorMessage, err)
 			}
+		}
+	}
+}
+
+func TestDefinable(t *testing.T) {
+	cases := []struct {
+		json    string
+		defined bool
+	}{
+		{`{"a":"foo"}`, true},
+		{`{"a":"foo", "b":"bar"}`, true},
+		{"{}", true},
+		{"null", false},
+	}
+
+	for _, tc := range cases {
+		var v Definable
+		v.UnmarshalJSON([]byte(tc.json))
+		if v.Def != tc.defined {
+			t.Errorf("UnmarshalJSON expected: %q. got: %q", tc.defined, v.Def)
 		}
 	}
 }


### PR DESCRIPTION
This is the unmarshal equivalent of the easyjson.Optional interface used
with easyjson marshallers.

If a struct type implements the interface, SetDefined() is called after the
type has been unmarshalled.

This avoids using pointer types (and therefore excessive allocations) for each Unmarshalling call.

Unmarshalling example:
```
type Request struct {
  Foo Foo `json:"foo,omitempty"`
  Bar Bar `json:"bar,omitempty"`
}

struct Foo {
...
  def bool `json:"-"`
}

func (f *Foo) SetDefined(d bool) {
	f.def = d
}

struct Bar {
  def bool `json:"-"`
}

func (b *Bar) SetDefined(d bool) {
	f.def = d
}
```

Valid JSON objects would get unmarshalled as follows:
```
{"foo": {...}}  => Request{Foo: Foo{...}, Bar: {def: false}}
{"bar": {...}} => Request{Foo: {def: false}, Bar: Bar{...}}
```