### PR TITLE
Allow reusing of buffer in BuildBytes()

### DIFF
--- a/jwriter/writer.go
+++ b/jwriter/writer.go
@@ -37,13 +37,14 @@ func (w *Writer) DumpTo(out io.Writer) (written int, err error) {
 	return w.Buffer.DumpTo(out)
 }
 
-// BuildBytes returns writer data as a single byte slice.
-func (w *Writer) BuildBytes() ([]byte, error) {
+// BuildBytes returns writer data as a single byte slice. You can optionally provide one byte slice
+// as argument that it will try to reuse.
+func (w *Writer) BuildBytes(reuse ...[]byte) ([]byte, error) {
 	if w.Error != nil {
 		return nil, w.Error
 	}
 
-	return w.Buffer.BuildBytes(), nil
+	return w.Buffer.BuildBytes(reuse...), nil
 }
 
 // RawByte appends raw binary data to the buffer.


### PR DESCRIPTION
This adds an optional parameter to `BuildBytes()` which allows for reusing
of a byte buffer. Because it's an optional parameter it will not break
backwards compatibility.

This allows people to use a `sync.Pool` for the buffers used by
`BuildBytes()` to reduce garbage generation.