### PR TITLE
Revert "Assert that no extraneous data remains after top-level tokens"

### DIFF
--- a/gen/decoder.go
+++ b/gen/decoder.go
@@ -340,14 +340,10 @@ func (g *Generator) genSliceArrayDecoder(t reflect.Type) error {
 	typ := g.getType(t)
 
 	fmt.Fprintln(g.out, "func "+fname+"(in *jlexer.Lexer, out *"+typ+") {")
-	fmt.Fprintln(g.out, " isTopLevel := in.IsStart()")
 	err := g.genTypeDecoderNoCheck(t, "*out", fieldTags{}, 1)
 	if err != nil {
 		return err
 	}
-	fmt.Fprintln(g.out, "  if isTopLevel {")
-	fmt.Fprintln(g.out, "    in.Consumed()")
-	fmt.Fprintln(g.out, "  }")
 	fmt.Fprintln(g.out, "}")
 
 	return nil
@@ -362,11 +358,7 @@ func (g *Generator) genStructDecoder(t reflect.Type) error {
 	typ := g.getType(t)
 
 	fmt.Fprintln(g.out, "func "+fname+"(in *jlexer.Lexer, out *"+typ+") {")
-	fmt.Fprintln(g.out, "  isTopLevel := in.IsStart()")
 	fmt.Fprintln(g.out, "  if in.IsNull() {")
-	fmt.Fprintln(g.out, "    if isTopLevel {")
-	fmt.Fprintln(g.out, "      in.Consumed()")
-	fmt.Fprintln(g.out, "    }")
 	fmt.Fprintln(g.out, "    in.Skip()")
 	fmt.Fprintln(g.out, "    return")
 	fmt.Fprintln(g.out, "  }")
@@ -412,9 +404,6 @@ func (g *Generator) genStructDecoder(t reflect.Type) error {
 	fmt.Fprintln(g.out, "    in.WantComma()")
 	fmt.Fprintln(g.out, "  }")
 	fmt.Fprintln(g.out, "  in.Delim('}')")
-	fmt.Fprintln(g.out, "  if isTopLevel {")
-	fmt.Fprintln(g.out, "    in.Consumed()")
-	fmt.Fprintln(g.out, "  }")
 
 	for _, f := range fs {
 		g.genRequiredFieldCheck(t, f)

--- a/jlexer/lexer.go
+++ b/jlexer/lexer.go
@@ -519,9 +519,8 @@ func (r *Lexer) SkipRecursive() {
 	r.err = &LexerError{
 		Reason: "EOF reached while skipping array/object or token",
 		Offset: r.pos,
-		Data:   string(r.Data[r.pos:]),
-	}
-}
+		Data: string(r.Data[r.pos:]),
+	}}
 
 // Raw fetches the next item recursively as a data slice
 func (r *Lexer) Raw() []byte {
@@ -530,34 +529,6 @@ func (r *Lexer) Raw() []byte {
 		return nil
 	}
 	return r.Data[r.start:r.pos]
-}
-
-// IsStart returns whether the lexer is positioned at the start
-// of an input string.
-func (r *Lexer) IsStart() bool {
-	return r.pos == 0
-}
-
-// Consumed reads all remaining bytes from the input, publishing an error if
-// there is anything but whitespace remaining.
-func (r *Lexer) Consumed() {
-	if r.pos > len(r.Data) {
-		return
-	}
-
-	for _, c := range r.Data[r.pos:] {
-		if c != ' ' && c != '\t' && c != '\r' && c != '\n' {
-			r.err = &LexerError{
-				Reason: "invalid character '" + string(c) + "' after top-level value",
-				Offset: r.pos,
-				Data:   string(r.Data[r.pos:]),
-			}
-			return
-		}
-
-		r.pos++
-		r.start++
-	}
 }
 
 // UnsafeString returns the string value if the token is a string literal.

--- a/jlexer/lexer_test.go
+++ b/jlexer/lexer_test.go
@@ -222,27 +222,3 @@ func TestInterface(t *testing.T) {
 		}
 	}
 }
-
-func TestConsumed(t *testing.T) {
-	for i, test := range []struct {
-		toParse   string
-		wantError bool
-	}{
-		{toParse: "", wantError: false},
-		{toParse: "   ", wantError: false},
-		{toParse: "\r\n", wantError: false},
-		{toParse: "\t\t", wantError: false},
-
-		{toParse: "{", wantError: true},
-	} {
-		l := Lexer{Data: []byte(test.toParse)}
-		l.Consumed()
-
-		err := l.Error()
-		if err != nil && !test.wantError {
-			t.Errorf("[%d, %q] Consumed() error: %v", i, test.toParse, err)
-		} else if err == nil && test.wantError {
-			t.Errorf("[%d, %q] Consumed() ok; want error", i, test.toParse)
-		}
-	}
-}


### PR DESCRIPTION
This (https://github.com/mailru/easyjson/pull/73) ended up causing some bugs in various situations. It should be reverted and reevaluated more thoroughly later.