### PR TITLE
fixes issue #79

### DIFF
--- a/jlexer/lexer.go
+++ b/jlexer/lexer.go
@@ -12,6 +12,9 @@ import (
 	"strconv"
 	"unicode/utf8"
 	"unsafe"
+	"errors"
+	"unicode/utf16"
+	"unicode"
 )
 
 // tokenKind determines type of a token.
@@ -269,6 +272,33 @@ func findStringLen(data []byte) (hasEscapes bool, length int) {
 	return false, len(data)
 }
 
+// getu4 decodes \uXXXX from the beginning of s, returning the hex value,
+// or it returns -1.
+func getu4(s []byte) rune {
+	if len(s) < 6 || s[0] != '\\' || s[1] != 'u' {
+		return -1
+	}
+	var val rune
+	for i := 2; i < len(s) && i < 6; i++ {
+		var v byte
+		c := s[i]
+		switch c {
+		case '0', '1', '2', '3', '4', '5', '6', '7', '8', '9':
+			v = c - '0'
+		case 'a', 'b', 'c', 'd', 'e', 'f':
+			v = c - 'a' + 10
+		case 'A', 'B', 'C', 'D', 'E', 'F':
+			v = c - 'A' + 10
+		default:
+			return -1
+		}
+
+		val <<= 4
+		val |= rune(v)
+	}
+	return val
+}
+
 // processEscape processes a single escape sequence and returns number of bytes processed.
 func (r *Lexer) processEscape(data []byte) (int, error) {
 	if len(data) < 2 {
@@ -296,39 +326,28 @@ func (r *Lexer) processEscape(data []byte) (int, error) {
 		r.token.byteValue = append(r.token.byteValue, '\t')
 		return 2, nil
 	case 'u':
-	default:
-		return 0, fmt.Errorf("syntax error")
-	}
-
-	var val rune
-
-	for i := 2; i < len(data) && i < 6; i++ {
-		var v byte
-		c = data[i]
-		switch c {
-		case '0', '1', '2', '3', '4', '5', '6', '7', '8', '9':
-			v = c - '0'
-		case 'a', 'b', 'c', 'd', 'e', 'f':
-			v = c - 'a' + 10
-		case 'A', 'B', 'C', 'D', 'E', 'F':
-			v = c - 'A' + 10
-		default:
-			return 0, fmt.Errorf("syntax error")
+		rr := getu4(data)
+		if rr < 0 {
+			return 0, errors.New("syntax error")
 		}
 
-		val <<= 4
-		val |= rune(v)
+		read := 6
+		if utf16.IsSurrogate(rr) {
+			rr1 := getu4(data[read:])
+			if dec := utf16.DecodeRune(rr, rr1); dec != unicode.ReplacementChar {
+				read += 6
+				rr = dec
+			} else {
+				rr = unicode.ReplacementChar
+			}
+		}
+		var d [4]byte
+		s := utf8.EncodeRune(d[:], rr)
+		r.token.byteValue = append(r.token.byteValue, d[:s]...)
+		return read, nil
 	}
 
-	l := utf8.RuneLen(val)
-	if l == -1 {
-		return 0, fmt.Errorf("invalid unicode escape")
-	}
-
-	var d [4]byte
-	utf8.EncodeRune(d[:], val)
-	r.token.byteValue = append(r.token.byteValue, d[:l]...)
-	return 6, nil
+	return 0, errors.New("syntax error")
 }
 
 // fetchString scans a string literal token.

--- a/jlexer/lexer_test.go
+++ b/jlexer/lexer_test.go
@@ -18,12 +18,15 @@ func TestString(t *testing.T) {
 		{toParse: `"\u0020"`, want: " "},
 		{toParse: `"\u0020-\t"`, want: " -\t"},
 		{toParse: `"\ufffd\uFFFD"`, want: "\ufffd\ufffd"},
+		{toParse: `"\ud83d\ude00"`, want: "😀"},
+		{toParse: `"\ud83d\ude08"`, want: "😈"},
+		{toParse: `"\ud8"`, wantError: true},
 
 		{toParse: `"test"junk`, want: "test"},
 
 		{toParse: `5`, wantError: true},        // not a string
 		{toParse: `"\x"`, wantError: true},     // invalid escape
-		{toParse: `"\ud800"`, wantError: true}, // invalid utf-8 char
+		{toParse: `"\ud800"`, want: "�"},      // invalid utf-8 char; return replacement char
 	} {
 		l := Lexer{Data: []byte(test.toParse)}
 


### PR DESCRIPTION
* handles invalid \u escape sequences
* falls back to unicode replacement character "�"

```
benchmark                                     old ns/op     new ns/op     delta
BenchmarkEJ_Unmarshal_M-8                     51707         52890         +2.29%
BenchmarkEJ_Unmarshal_S-8                     685           695           +1.46%
BenchmarkEJ_Marshal_M-8                       19262         19303         +0.21%
BenchmarkEJ_Marshal_L-8                       912472        921312        +0.97%
BenchmarkEJ_Marshal_L_ToWriter-8              830432        843928        +1.63%
BenchmarkEJ_Marshal_M_Parallel-8              5983          5789          -3.24%
BenchmarkEJ_Marshal_M_ToWriter-8              17539         17662         +0.70%
BenchmarkEJ_Marshal_M_ToWriter_Parallel-8     4249          4204          -1.06%
BenchmarkEJ_Marshal_L_Parallel-8              319229        330672        +3.58%
BenchmarkEJ_Marshal_L_ToWriter_Parallel-8     196869        200514        +1.85%
BenchmarkEJ_Marshal_S-8                       287           286           -0.35%
BenchmarkEJ_Marshal_S_Parallel-8              97.5          89.3          -8.41%

benchmark                                     old MB/s     new MB/s     speedup
BenchmarkEJ_Unmarshal_M-8                     251.88       246.24       0.98x
BenchmarkEJ_Unmarshal_S-8                     119.57       117.88       0.99x
BenchmarkEJ_Marshal_M-8                       461.61       460.63       1.00x
BenchmarkEJ_Marshal_L-8                       487.31       482.64       0.99x
BenchmarkEJ_Marshal_L_ToWriter-8              535.46       526.89       0.98x
BenchmarkEJ_Marshal_M_Parallel-8              2176.69      2249.64      1.03x
BenchmarkEJ_Marshal_M_ToWriter-8              506.98       503.45       0.99x
BenchmarkEJ_Marshal_M_ToWriter_Parallel-8     2092.38      2115.05      1.01x
BenchmarkEJ_Marshal_L_Parallel-8              1392.91      1344.71      0.97x
BenchmarkEJ_Marshal_L_ToWriter_Parallel-8     2258.66      2217.59      0.98x
BenchmarkEJ_Marshal_S-8                       282.21       283.04       1.00x
BenchmarkEJ_Marshal_S_Parallel-8              830.73       906.78       1.09x

benchmark                                     old allocs     new allocs     delta
BenchmarkEJ_Unmarshal_M-8                     128            128            +0.00%
BenchmarkEJ_Unmarshal_S-8                     3              3              +0.00%
BenchmarkEJ_Marshal_M-8                       10             10             +0.00%
BenchmarkEJ_Marshal_L-8                       29             29             +0.00%
BenchmarkEJ_Marshal_L_ToWriter-8              24             24             +0.00%
BenchmarkEJ_Marshal_M_Parallel-8              9              9              +0.00%
BenchmarkEJ_Marshal_M_ToWriter-8              8              8              +0.00%
BenchmarkEJ_Marshal_M_ToWriter_Parallel-8     8              8              +0.00%
BenchmarkEJ_Marshal_L_Parallel-8              34             34             +0.00%
BenchmarkEJ_Marshal_L_ToWriter_Parallel-8     24             24             +0.00%
BenchmarkEJ_Marshal_S-8                       1              1              +0.00%
BenchmarkEJ_Marshal_S_Parallel-8              1              1              +0.00%

benchmark                                     old bytes     new bytes     delta
BenchmarkEJ_Unmarshal_M-8                     9792          9792          +0.00%
BenchmarkEJ_Unmarshal_S-8                     128           128           +0.00%
BenchmarkEJ_Marshal_M-8                       10377         10378         +0.01%
BenchmarkEJ_Marshal_L-8                       462278        462542        +0.06%
BenchmarkEJ_Marshal_L_ToWriter-8              2641          2641          +0.00%
BenchmarkEJ_Marshal_M_Parallel-8              10479         10477         -0.02%
BenchmarkEJ_Marshal_M_ToWriter-8              741           741           +0.00%
BenchmarkEJ_Marshal_M_ToWriter_Parallel-8     757           758           +0.13%
BenchmarkEJ_Marshal_L_Parallel-8              525769        528920        +0.60%
BenchmarkEJ_Marshal_L_ToWriter_Parallel-8     5270          4312          -18.18%
BenchmarkEJ_Marshal_S-8                       128           128           +0.00%
BenchmarkEJ_Marshal_S_Parallel-8              128           128           +0.00%
```