### PR TITLE
Changing to fixed ordering for generator when multiple types in single file

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 )
 
 const genPackage = "github.com/mailru/easyjson/gen"
@@ -59,6 +60,7 @@ func (g *Generator) writeStub() error {
 		fmt.Fprintln(f, ")")
 	}
 
+	sort.Strings(g.Types)
 	for _, t := range g.Types {
 		fmt.Fprintln(f)
 		if !g.NoStdMarshalers {
@@ -114,6 +116,8 @@ func (g *Generator) writeMain() (path string, err error) {
 	if g.NoStdMarshalers {
 		fmt.Fprintln(f, "  g.NoStdMarshalers()")
 	}
+
+	sort.Strings(g.Types)
 	for _, v := range g.Types {
 		fmt.Fprintln(f, "  g.Add(pkg.EasyJSON_exporter_"+v+"(nil))")
 	}

--- a/gen/generator.go
+++ b/gen/generator.go
@@ -153,7 +153,7 @@ func (g *Generator) printHeader() {
 
 	sort.Strings(aliases)
 	fmt.Println("import (")
-	for _, alias := range g.imports {
+	for _, alias := range aliases {
 		fmt.Printf("  %s %q\n", alias, byAlias[alias])
 	}
 


### PR DESCRIPTION
Fixed ordering in bootstrap and generator when there are multiple types in a single file. Fixes an issue where multiple/repeated runs were not generating the same output, which was frustrating when run across a large project with thousands of types.