### PR TITLE
fix bugs in generator output for named types inside anonymous structs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,8 @@ generate: root build
 		.root/src/$(PKG)/tests/snake.go \
 		.root/src/$(PKG)/tests/data.go \
 		.root/src/$(PKG)/tests/omitempty.go \
-		.root/src/$(PKG)/tests/nothing.go
+		.root/src/$(PKG)/tests/nothing.go \
+		.root/src/$(PKG)/tests/named_type.go
 
 	.root/bin/easyjson -all .root/src/$(PKG)/tests/data.go 
 	.root/bin/easyjson -all .root/src/$(PKG)/tests/nothing.go
@@ -29,6 +30,7 @@ generate: root build
 	.root/bin/easyjson -omit_empty .root/src/$(PKG)/tests/omitempty.go
 	.root/bin/easyjson -build_tags=use_easyjson .root/src/$(PKG)/benchmark/data.go
 	.root/bin/easyjson .root/src/$(PKG)/tests/nested_easy.go
+	.root/bin/easyjson .root/src/$(PKG)/tests/named_type.go
 
 test: generate root
 	go test \

--- a/gen/generator.go
+++ b/gen/generator.go
@@ -264,7 +264,12 @@ func (g *Generator) getType(t reflect.Type) string {
 			lines := make([]string, 0, nf)
 			for i := 0; i < nf; i++ {
 				f := t.Field(i)
-				lines = append(lines, f.Name+" "+g.getType(f.Type))
+				line := f.Name + " " + g.getType(f.Type)
+				t := f.Tag
+				if t != "" {
+					line += " " + escapeTag(t)
+				}
+				lines = append(lines, line)
 			}
 			return strings.Join([]string{"struct { ", strings.Join(lines, "; "), " }"}, "")
 		}
@@ -273,6 +278,16 @@ func (g *Generator) getType(t reflect.Type) string {
 		return t.Name()
 	}
 	return g.pkgAlias(t.PkgPath()) + "." + t.Name()
+}
+
+// escape a struct field tag string back to source code
+func escapeTag(tag reflect.StructTag) string {
+	t := string(tag)
+	if strings.ContainsRune(t, '`') {
+		// there are ` in the string; we can't use ` to enclose the string
+		return strconv.Quote(t)
+	}
+	return "`" + t + "`"
 }
 
 // uniqueVarName returns a file-unique name that can be used for generated variables.

--- a/tests/basic_test.go
+++ b/tests/basic_test.go
@@ -36,6 +36,7 @@ var testCases = []struct {
 	{&deepNestValue, deepNestString},
 	{&IntsValue, IntsString},
 	{&mapStringStringValue, mapStringStringString},
+	{&namedTypeValue, namedTypeValueString},
 }
 
 func TestMarshal(t *testing.T) {

--- a/tests/named_type.go
+++ b/tests/named_type.go
@@ -5,11 +5,15 @@ type NamedType struct {
 	Inner struct {
 		// easyjson is mistakenly naming the type of this field 'tests.MyString' in the generated output
 		// something about a named type inside an anonmymous type is triggering this bug
-		Field MyString
+		Field  MyString
+		Field2 int
 	}
 }
 
 type MyString string
 
-var namedTypeValue = NamedType{Inner: struct{ Field MyString }{Field: "test"}}
+var namedTypeValue = NamedType{Inner: struct {
+	Field  MyString
+	Field2 int
+}{Field: "test"}}
 var namedTypeValueString = `{"Inner":{"Field":"test"}}`

--- a/tests/named_type.go
+++ b/tests/named_type.go
@@ -1,0 +1,15 @@
+package tests
+
+//easyjson:json
+type NamedType struct {
+	Inner struct {
+		// easyjson is mistakenly naming the type of this field 'tests.MyString' in the generated output
+		// something about a named type inside an anonmymous type is triggering this bug
+		Field MyString
+	}
+}
+
+type MyString string
+
+var namedTypeValue = NamedType{Inner: struct{ Field MyString }{Field: "test"}}
+var namedTypeValueString = `{"Inner":{"Field":"test"}}`

--- a/tests/named_type.go
+++ b/tests/named_type.go
@@ -5,15 +5,18 @@ type NamedType struct {
 	Inner struct {
 		// easyjson is mistakenly naming the type of this field 'tests.MyString' in the generated output
 		// something about a named type inside an anonmymous type is triggering this bug
-		Field  MyString
-		Field2 int
+		Field  MyString `tag:"value"`
+		Field2 int      "tag:\"value with ` in it\""
 	}
 }
 
 type MyString string
 
-var namedTypeValue = NamedType{Inner: struct {
-	Field  MyString
-	Field2 int
-}{Field: "test"}}
-var namedTypeValueString = `{"Inner":{"Field":"test"}}`
+var namedTypeValue NamedType
+
+func init() {
+	namedTypeValue.Inner.Field = "test"
+	namedTypeValue.Inner.Field2 = 123
+}
+
+var namedTypeValueString = `{"Inner":{"Field":"test","Field2":123}}`


### PR DESCRIPTION
Named types inside anonymous structs aren't getting the proper package prefix. For example field S in

  package P
  type T2 <something>
  type T struct {
    S struct {
      F T2
    }
  }

gets converted by the generator.go into
  struct { 
    F P.T2
  }

Note the "P." prefix. It's wrong. We are already in package P.

This pull request fixes this and similar cases.

----------------------

The fix is to not use the output of reflect.Type.String(). reflect.Type.String() almost returns the right thing, but not quite. It qualifies all named types with their package. That breaks 2 ways:
  1) when the type's package == g.pkgPath
  2) when the type's package name clashes with a package alias easyjson picked

The fix is to enumerate the anonymous struct's fields ourself, converting each field's type ourself.