### PR TITLE
Add -lcfirst flag.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Usage of .root/bin/easyjson:
         generate un-/marshallers for all structs in a file
   -build_tags string
         build tags to add to generated file
+  -lcfirst
+        lower case the first letter of each field name
   -leave_temps
         do not delete temporary files
   -no_std_marshalers
@@ -40,6 +42,8 @@ struct A{}
 ```
 
 `-snake_case` tells easyjson to generate snake\_case field names by default (unless explicitly overriden by a field tag). The CamelCase to snake\_case conversion algorithm should work in most cases (e.g. HTTPVersion will be converted to http_version). There can be names like JSONHTTPRPC where the conversion will return an unexpected result (jsonhttprpc without underscores),  but such names require a dictionary to do the conversion and may be ambiguous.
+
+`-lcfirst` tells easyjson to lowercase the first letter of each field name (unless explicitly overridden by a field tag).
 
 `-build_tags` will add corresponding build tag line for the generated file.
 ## marshaller/unmarshaller interfaces

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -23,6 +23,7 @@ type Generator struct {
 
 	NoStdMarshalers bool
 	SnakeCase       bool
+	LCFirst         bool
 	OmitEmpty       bool
 
 	OutName   string
@@ -107,6 +108,8 @@ func (g *Generator) writeMain() (path string, err error) {
 	}
 	if g.SnakeCase {
 		fmt.Fprintln(f, "  g.UseSnakeCase()")
+	} else if g.LCFirst {
+		fmt.Fprintln(f, "  g.UseLCFirst()")
 	}
 	if g.OmitEmpty {
 		fmt.Fprintln(f, "  g.OmitEmpty()")

--- a/easyjson/main.go
+++ b/easyjson/main.go
@@ -18,6 +18,7 @@ import (
 
 var buildTags = flag.String("build_tags", "", "build tags to add to generated file")
 var snakeCase = flag.Bool("snake_case", false, "use snake_case names instead of CamelCase by default")
+var lcFirst = flag.Bool("lcfirst", false, "lower case the first letter of each field name")
 var noStdMarshalers = flag.Bool("no_std_marshalers", false, "don't generate MarshalJSON/UnmarshalJSON methods")
 var omitEmpty = flag.Bool("omit_empty", false, "omit empty fields by default")
 var allStructs = flag.Bool("all", false, "generate un-/marshallers for all structs in a file")
@@ -59,6 +60,7 @@ func generate(fname string) (err error) {
 		PkgName:         p.PkgName,
 		Types:           p.StructNames,
 		SnakeCase:       *snakeCase,
+		LCFirst:         *lcFirst,
 		NoStdMarshalers: *noStdMarshalers,
 		OmitEmpty:       *omitEmpty,
 		LeaveTemps:      *leaveTemps,

--- a/gen/generator.go
+++ b/gen/generator.go
@@ -60,7 +60,7 @@ func NewGenerator(filename string) *Generator {
 		imports: map[string]string{
 			pkgWriter:       "jwriter",
 			pkgLexer:        "jlexer",
-			pkgEasyjson:      "easyjson",
+			pkgEasyjson:     "easyjson",
 			"encoding/json": "json",
 		},
 		fieldNamer:    DefaultFieldNamer{},
@@ -97,6 +97,11 @@ func (g *Generator) SetFieldNamer(n FieldNamer) {
 // UseSnakeCase sets snake_case field naming strategy.
 func (g *Generator) UseSnakeCase() {
 	g.fieldNamer = SnakeCaseFieldNamer{}
+}
+
+// UseLCFirst sets lcfirst field naming strategy.
+func (g *Generator) UseLCFirst() {
+	g.fieldNamer = LCFirstFieldNamer{}
 }
 
 // NoStdMarshalers instructs not to generate standard MarshalJSON/UnmarshalJSON
@@ -333,6 +338,19 @@ func (DefaultFieldNamer) GetJSONFieldName(t reflect.Type, f reflect.StructField)
 		return jsonName
 	} else {
 		return f.Name
+	}
+}
+
+// LCFirstFieldNamer implements naming policy that honors json tag if present,
+// and otherwise uses the field name with the first character in lower case.
+type LCFirstFieldNamer struct{}
+
+func (LCFirstFieldNamer) GetJSONFieldName(t reflect.Type, f reflect.StructField) string {
+	jsonName := strings.Split(f.Tag.Get("json"), ",")[0]
+	if jsonName != "" {
+		return jsonName
+	} else {
+		return strings.ToLower(f.Name[:1]) + f.Name[1:]
 	}
 }
 


### PR DESCRIPTION
The -lcfirst flag lowercases the first letter in each field name (unless overridden with a field tag).

This is useful when working with JSON defined by another, non-Go application, which uses lowerCamelCase field names.  Go requires that these be changed to upper case in the structure definition, and it's tedious to have to add a \`json:"..."\` tag on every field just to correct the initial capital.