### PR TITLE
Prevent bugs caused by multiple Close calls

### DIFF
--- a/buffer/pool.go
+++ b/buffer/pool.go
@@ -252,6 +252,8 @@ func (r *readCloser) Close() error {
 	for _, buf := range r.bufs {
 		putBuf(buf)
 	}
+	// In case Close gets called multiple times.
+	r.bufs = nil
 
 	return nil
 }


### PR DESCRIPTION
See: https://github.com/golang/go/issues/19186
When the body isn't fully read and Close is called multiple times we put the same buffer in the pool multiple times causing it to be reused by multiple goroutines at the same time.