### PR TITLE
package path with "." bug fix

### DIFF
--- a/gen/generator.go
+++ b/gen/generator.go
@@ -213,11 +213,11 @@ func fixPkgPathVendoring(pkgPath string) string {
 }
 
 func fixAliasName(alias string) string {
-	alias := strings.Replace(
-			strings.Replace(path.Base(pkgPath), ".", "_", -1),
-			"-",
-			"_",
-			-1,
+	alias = strings.Replace(
+		strings.Replace(path.Base(pkgPath), ".", "_", -1),
+		"-",
+		"_",
+		-1,
 	)
 	return alias
 }

--- a/gen/generator.go
+++ b/gen/generator.go
@@ -220,7 +220,12 @@ func (g *Generator) pkgAlias(pkgPath string) string {
 	}
 
 	for i := 0; ; i++ {
-		alias := path.Base(pkgPath)
+		alias := strings.Replace(
+			strings.Replace(path.Base(pkgPath), ".", "_", -1),
+			"-",
+			"_",
+			-1,
+		)
 		if i > 0 {
 			alias += fmt.Sprint(i)
 		}


### PR DESCRIPTION
I have my private package with some structures I depend on, stored by path like `.../my-private-structs.git`. In this case nothing works... This patch fix it.