### PR TITLE
Proper encoding.TextMarshaler handling

### DIFF
--- a/gen/decoder.go
+++ b/gen/decoder.go
@@ -68,8 +68,8 @@ func (g *Generator) genTypeDecoder(t reflect.Type, out string, tags fieldTags, i
 
 	unmarshalerIface = reflect.TypeOf((*encoding.TextUnmarshaler)(nil)).Elem()
 	if reflect.PtrTo(t).Implements(unmarshalerIface) {
-		fmt.Fprintln(g.out, ws+"if data := in.UnsafeString(); in.Ok() {")
-		fmt.Fprintln(g.out, ws+"  in.AddError( ("+out+").UnmarshalText([]byte(data)) )")
+		fmt.Fprintln(g.out, ws+"if data := in.UnsafeBytes(); in.Ok() {")
+		fmt.Fprintln(g.out, ws+"  in.AddError( ("+out+").UnmarshalText(data) )")
 		fmt.Fprintln(g.out, ws+"}")
 		return nil
 	}

--- a/gen/decoder.go
+++ b/gen/decoder.go
@@ -1,6 +1,7 @@
 package gen
 
 import (
+	"encoding"
 	"encoding/json"
 	"fmt"
 	"reflect"
@@ -61,6 +62,14 @@ func (g *Generator) genTypeDecoder(t reflect.Type, out string, tags fieldTags, i
 	if reflect.PtrTo(t).Implements(unmarshalerIface) {
 		fmt.Fprintln(g.out, ws+"if data := in.Raw(); in.Ok() {")
 		fmt.Fprintln(g.out, ws+"  in.AddError( ("+out+").UnmarshalJSON(data) )")
+		fmt.Fprintln(g.out, ws+"}")
+		return nil
+	}
+
+	unmarshalerIface = reflect.TypeOf((*encoding.TextUnmarshaler)(nil)).Elem()
+	if reflect.PtrTo(t).Implements(unmarshalerIface) {
+		fmt.Fprintln(g.out, ws+"if data := in.UnsafeString(); in.Ok() {")
+		fmt.Fprintln(g.out, ws+"  in.AddError( ("+out+").UnmarshalText([]byte(data)) )")
 		fmt.Fprintln(g.out, ws+"}")
 		return nil
 	}

--- a/gen/encoder.go
+++ b/gen/encoder.go
@@ -1,6 +1,7 @@
 package gen
 
 import (
+	"encoding"
 	"encoding/json"
 	"fmt"
 	"reflect"
@@ -92,6 +93,12 @@ func (g *Generator) genTypeEncoder(t reflect.Type, in string, tags fieldTags, in
 	marshalerIface = reflect.TypeOf((*json.Marshaler)(nil)).Elem()
 	if reflect.PtrTo(t).Implements(marshalerIface) {
 		fmt.Fprintln(g.out, ws+"out.Raw( ("+in+").MarshalJSON() )")
+		return nil
+	}
+
+	marshalerIface = reflect.TypeOf((*encoding.TextMarshaler)(nil)).Elem()
+	if reflect.PtrTo(t).Implements(marshalerIface) {
+		fmt.Fprintln(g.out, ws+"out.RawText( ("+in+").MarshalText() )")
 		return nil
 	}
 

--- a/jlexer/lexer.go
+++ b/jlexer/lexer.go
@@ -618,6 +618,12 @@ func (r *Lexer) UnsafeString() string {
 	return ret
 }
 
+// UnsafeBytes returns the byte slice if the token is a string literal.
+func (r *Lexer) UnsafeBytes() []byte {
+	_, ret := r.unsafeString()
+	return ret
+}
+
 // String reads a string literal.
 func (r *Lexer) String() string {
 	if r.token.kind == tokenUndef && r.Ok() {

--- a/jwriter/writer.go
+++ b/jwriter/writer.go
@@ -68,7 +68,7 @@ func (w *Writer) RawString(s string) {
 	w.Buffer.AppendString(s)
 }
 
-// RawByte appends raw binary data to the buffer or sets the error if it is given. Useful for
+// Raw appends raw binary data to the buffer or sets the error if it is given. Useful for
 // calling with results of MarshalJSON-like functions.
 func (w *Writer) Raw(data []byte, err error) {
 	switch {
@@ -78,6 +78,23 @@ func (w *Writer) Raw(data []byte, err error) {
 		w.Error = err
 	case len(data) > 0:
 		w.Buffer.AppendBytes(data)
+	default:
+		w.RawString("null")
+	}
+}
+
+// RawText encloses raw binary data in quotes and appends in to the buffer.
+// Useful for calling with results of MarshalText-like functions.
+func (w *Writer) RawText(data []byte, err error) {
+	switch {
+	case w.Error != nil:
+		return
+	case err != nil:
+		w.Error = err
+	case len(data) > 0:
+		w.Buffer.AppendByte('"')
+		w.Buffer.AppendBytes(data)
+		w.Buffer.AppendByte('"')
 	default:
 		w.RawString("null")
 	}

--- a/jwriter/writer.go
+++ b/jwriter/writer.go
@@ -92,9 +92,7 @@ func (w *Writer) RawText(data []byte, err error) {
 	case err != nil:
 		w.Error = err
 	case len(data) > 0:
-		w.Buffer.AppendByte('"')
-		w.Buffer.AppendBytes(data)
-		w.Buffer.AppendByte('"')
+		w.String(string(data))
 	default:
 		w.RawString("null")
 	}

--- a/tests/basic_test.go
+++ b/tests/basic_test.go
@@ -28,6 +28,7 @@ var testCases = []struct {
 	{&optsValue, optsString},
 	{&rawValue, rawString},
 	{&stdMarshalerValue, stdMarshalerString},
+	{&userMarshalerValue, userMarshalerString},
 	{&unexportedStructValue, unexportedStructString},
 	{&excludedFieldValue, excludedFieldString},
 	{&sliceValue, sliceString},

--- a/tests/data.go
+++ b/tests/data.go
@@ -3,6 +3,7 @@ package tests
 import (
 	"fmt"
 	"math"
+	"net"
 	"time"
 
 	"github.com/mailru/easyjson"
@@ -392,11 +393,54 @@ var rawString = `{` +
 	`}`
 
 type StdMarshaler struct {
-	T time.Time
+	T  time.Time
+	IP net.IP
 }
 
-var stdMarshalerValue = StdMarshaler{T: time.Date(2016, 01, 02, 14, 15, 10, 0, time.UTC)}
-var stdMarshalerString = `{"T":"2016-01-02T14:15:10Z"}`
+var stdMarshalerValue = StdMarshaler{
+	T:  time.Date(2016, 01, 02, 14, 15, 10, 0, time.UTC),
+	IP: net.IPv4(192, 168, 0, 1),
+}
+var stdMarshalerString = `{` +
+	`"T":"2016-01-02T14:15:10Z",` +
+	`"IP":"192.168.0.1"` +
+	`}`
+
+type UserMarshaler struct {
+	V vMarshaler
+	T tMarshaler
+}
+
+type vMarshaler net.IP
+
+func (v vMarshaler) MarshalJSON() ([]byte, error) {
+	return []byte(`"0::0"`), nil
+}
+
+func (v *vMarshaler) UnmarshalJSON([]byte) error {
+	*v = vMarshaler(net.IPv6zero)
+	return nil
+}
+
+type tMarshaler net.IP
+
+func (v tMarshaler) MarshalText() ([]byte, error) {
+	return []byte(`[0::0]`), nil
+}
+
+func (v *tMarshaler) UnmarshalText([]byte) error {
+	*v = tMarshaler(net.IPv6zero)
+	return nil
+}
+
+var userMarshalerValue = UserMarshaler{
+	V: vMarshaler(net.IPv6zero),
+	T: tMarshaler(net.IPv6zero),
+}
+var userMarshalerString = `{` +
+	`"V":"0::0",` +
+	`"T":"[0::0]"` +
+	`}`
 
 type unexportedStruct struct {
 	Value string


### PR DESCRIPTION
Currently easyjson doesn't handle [encoding.TextMarshaler][1] interfaces. This leads to a situation where types like [net.IP][2] are handled as Base64Bytes:

```go
ip := net.IPv4(192, 168, 0, 1)

s, _ := easyjson.Marshal(ip)
// "AAAAAAAAAAAAAP//wKgAAQ=="

s, _ := json.Marshal(ip)
// "192.168.0.1"
```

[1]: https://godoc.org/encoding#TextMarshaler
[2]: https://godoc.org/net#IP