### PR TITLE
Replace dash with empty character in import alias name

### DIFF
--- a/gen/generator.go
+++ b/gen/generator.go
@@ -212,6 +212,11 @@ func fixPkgPathVendoring(pkgPath string) string {
 	return pkgPath
 }
 
+func fixAliasName(alias string) string {
+	alias = strings.Replace(alias, "-", "", -1)
+	return alias
+}
+
 // pkgAlias creates and returns and import alias for a given package.
 func (g *Generator) pkgAlias(pkgPath string) string {
 	pkgPath = fixPkgPathVendoring(pkgPath)
@@ -220,7 +225,7 @@ func (g *Generator) pkgAlias(pkgPath string) string {
 	}
 
 	for i := 0; ; i++ {
-		alias := path.Base(pkgPath)
+		alias := fixAliasName(path.Base(pkgPath))
 		if i > 0 {
 			alias += fmt.Sprint(i)
 		}


### PR DESCRIPTION
I have "-" characted in some of my imports, and generated file has bad syntax in import section, which causing "Bootstrap failed" error. Fixed by replacing "-" character with empty character in aliases names.