### PR TITLE
Updated getPkgPath to use package filepath instead of path

### DIFF
--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1,0 +1,26 @@
+package parser
+
+import "testing"
+
+func TestGetPkgPath(t *testing.T) {
+	cases := []struct {
+		fname string
+		isDir bool
+	}{
+		{"parser.go", false},
+		{".", true},
+	}
+	exp := "github.com/mailru/easyjson/parser"
+
+	for _, tc := range cases {
+
+		pkg, err := getPkgPath(tc.fname, tc.isDir)
+		if err != nil {
+			t.Error(err)
+		}
+		if pkg != exp {
+			t.Errorf("in: \"%s\" isDir: %v want: %s got: %s", tc.fname, tc.isDir, exp, pkg)
+		}
+	}
+
+}

--- a/parser/parser_unix.go
+++ b/parser/parser_unix.go
@@ -2,32 +2,6 @@
 
 package parser
 
-import (
-	"fmt"
-	"os"
-	"path"
-	"strings"
-)
-
-func getPkgPath(fname string, isDir bool) (string, error) {
-	if !path.IsAbs(fname) {
-		pwd, err := os.Getwd()
-		if err != nil {
-			return "", err
-		}
-		fname = path.Join(pwd, fname)
-	}
-
-	for _, p := range strings.Split(os.Getenv("GOPATH"), ":") {
-		prefix := path.Join(p, "src") + "/"
-		if rel := strings.TrimPrefix(fname, prefix); rel != fname {
-			if !isDir {
-				return path.Dir(rel), nil
-			} else {
-				return path.Clean(rel), nil
-			}
-		}
-	}
-
-	return "", fmt.Errorf("file '%v' is not in GOPATH", fname)
+func normalizePath(path string) string {
+	return path
 }

--- a/parser/parser_windows.go
+++ b/parser/parser_windows.go
@@ -1,37 +1,9 @@
 package parser
 
 import (
-	"fmt"
-	"os"
-	"path"
 	"strings"
 )
 
 func normalizePath(path string) string {
 	return strings.Replace(path, "\\", "/", -1)
-}
-
-func getPkgPath(fname string, isDir bool) (string, error) {
-	if !path.IsAbs(fname) {
-		pwd, err := os.Getwd()
-		if err != nil {
-			return "", err
-		}
-		fname = path.Join(pwd, fname)
-	}
-
-	fname = normalizePath(fname)
-
-	for _, p := range strings.Split(os.Getenv("GOPATH"), ";") {
-		prefix := path.Join(normalizePath(p), "src") + "/"
-		if rel := strings.TrimPrefix(fname, prefix); rel != fname {
-			if !isDir {
-				return path.Dir(rel), nil
-			} else {
-				return path.Clean(rel), nil
-			}
-		}
-	}
-
-	return "", fmt.Errorf("file '%v' is not in GOPATH", fname)
 }


### PR DESCRIPTION
os.Getwd() on Windows sometimes returns an upper case drive letter and sometimes a lower case drive letter. It changes depending on if the program is run as a binary or from a "go run .." command line.
Anyway, this results in GOPATH not being equal to the working directory unless GOPATH is using an upper case drive letter. getPkgPath then returns "file '%v' is not in GOPATH"

Switching to filepath means you can probably eliminate the _unix and _windows files completely, but I didn't want to change the code too much so I left the normalizePath() function in there. I also wrote some a test as well. You'll probably want to move that to your test directory if you decide to keep it.