### PR TITLE
Update lexer.Consumed() to not overwrite existing error

### DIFF
--- a/jlexer/lexer.go
+++ b/jlexer/lexer.go
@@ -582,11 +582,11 @@ func (r *Lexer) Consumed() {
 
 	for _, c := range r.Data[r.pos:] {
 		if c != ' ' && c != '\t' && c != '\r' && c != '\n' {
-			r.fatalError = &LexerError{
+			r.addError(&LexerError{
 				Reason: "invalid character '" + string(c) + "' after top-level value",
 				Offset: r.pos,
 				Data:   string(r.Data[r.pos:]),
-			}
+			})
 			return
 		}
 

--- a/jlexer/lexer.go
+++ b/jlexer/lexer.go
@@ -582,7 +582,7 @@ func (r *Lexer) Consumed() {
 
 	for _, c := range r.Data[r.pos:] {
 		if c != ' ' && c != '\t' && c != '\r' && c != '\n' {
-			r.addError(&LexerError{
+			r.AddError(&LexerError{
 				Reason: "invalid character '" + string(c) + "' after top-level value",
 				Offset: r.pos,
 				Data:   string(r.Data[r.pos:]),


### PR DESCRIPTION
I have the following json string

```
{"request":{"stringField":"foo"}}
```

I get the following message when i try to parse it :

```
"parse error: invalid character '}' after top-level value near offset 13 of '}'"
```

I expected the message : 

```
"parse error: "boolField" is required"
```

This is my go struct

```
type BarRequest struct {
	StringField string `json:"stringField,required"`
	BoolField   bool   `json:"boolField,required"`
}

type Bar_Normal_Args struct {
	Request *BarRequest `json:"request,required"`
}
```

The checking for extra bytes on the end of the json top level object check overwrites the useful message with a cryptic undebuggable message.