### PR TITLE
Add lowerCamelCase naming strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ Usage of easyjson:
     	process the whole package instead of just the given file
   -snake_case
     	use snake_case names instead of CamelCase by default
+  --lower-camel-case
+        use lowerCamelCase instead of CamelCase by default
   -stubs
     	only generate stubs for marshaler/unmarshaler funcs
 ```

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Usage of easyjson:
     	process the whole package instead of just the given file
   -snake_case
     	use snake_case names instead of CamelCase by default
-  --lower-camel-case
+  -lower_camel_case
         use lowerCamelCase instead of CamelCase by default
   -stubs
     	only generate stubs for marshaler/unmarshaler funcs

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -111,7 +111,7 @@ func (g *Generator) writeMain() (path string, err error) {
 	if g.SnakeCase {
 		fmt.Fprintln(f, "  g.UseSnakeCase()")
 	}
-	if g.SnakeCase {
+	if g.LowerCamelCase {
 		fmt.Fprintln(f, "  g.UseLowerCamelCase()")
 	}
 	if g.OmitEmpty {

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -24,6 +24,7 @@ type Generator struct {
 
 	NoStdMarshalers bool
 	SnakeCase       bool
+	LowerCamelCase  bool
 	OmitEmpty       bool
 
 	OutName   string
@@ -109,6 +110,9 @@ func (g *Generator) writeMain() (path string, err error) {
 	}
 	if g.SnakeCase {
 		fmt.Fprintln(f, "  g.UseSnakeCase()")
+	}
+	if g.SnakeCase {
+		fmt.Fprintln(f, "  g.UseLowerCamelCase()")
 	}
 	if g.OmitEmpty {
 		fmt.Fprintln(f, "  g.OmitEmpty()")

--- a/easyjson/main.go
+++ b/easyjson/main.go
@@ -18,6 +18,7 @@ import (
 
 var buildTags = flag.String("build_tags", "", "build tags to add to generated file")
 var snakeCase = flag.Bool("snake_case", false, "use snake_case names instead of CamelCase by default")
+var lowerCamelCase = flag.Bool("lower_camel_case", false, "use lowerCamelCase names instead of CamelCase by default")
 var noStdMarshalers = flag.Bool("no_std_marshalers", false, "don't generate MarshalJSON/UnmarshalJSON funcs")
 var omitEmpty = flag.Bool("omit_empty", false, "omit empty fields by default")
 var allStructs = flag.Bool("all", false, "generate marshaler/unmarshalers for all structs in a file")
@@ -59,6 +60,7 @@ func generate(fname string) (err error) {
 		PkgName:         p.PkgName,
 		Types:           p.StructNames,
 		SnakeCase:       *snakeCase,
+		LowerCamelCase:  *lowerCamelCase,
 		NoStdMarshalers: *noStdMarshalers,
 		OmitEmpty:       *omitEmpty,
 		LeaveTemps:      *leaveTemps,

--- a/gen/generator.go
+++ b/gen/generator.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 	"unicode"
+	"unicode/utf8"
 )
 
 const pkgWriter = "github.com/mailru/easyjson/jwriter"
@@ -97,6 +98,11 @@ func (g *Generator) SetFieldNamer(n FieldNamer) {
 // UseSnakeCase sets snake_case field naming strategy.
 func (g *Generator) UseSnakeCase() {
 	g.fieldNamer = SnakeCaseFieldNamer{}
+}
+
+// UseLowerCamelCase sets lowerCamelCase field naming strategy.
+func (g *Generator) UseLowerCamelCase() {
+	g.fieldNamer = LowerCamelCaseFieldNamer{}
 }
 
 // NoStdMarshalers instructs not to generate standard MarshalJSON/UnmarshalJSON
@@ -371,6 +377,25 @@ func (DefaultFieldNamer) GetJSONFieldName(t reflect.Type, f reflect.StructField)
 		return jsonName
 	} else {
 		return f.Name
+	}
+}
+
+// LowerCamelCaseFieldNamer
+type LowerCamelCaseFieldNamer struct {}
+func lowerFirst(s string) string {
+	if s == "" {
+		return ""
+	}
+	r, n := utf8.DecodeRuneInString(s)
+	return string(unicode.ToLower(r)) + s[n:]
+}
+
+func (LowerCamelCaseFieldNamer) GetJSONFieldName(t reflect.Type, f reflect.StructField) string {
+	jsonName := strings.Split(f.Tag.Get("json"), ",")[0]
+	if jsonName != "" {
+		return jsonName
+	} else {
+		return lowerFirst(f.Name)
 	}
 }
 

--- a/gen/generator_test.go
+++ b/gen/generator_test.go
@@ -28,6 +28,28 @@ func TestCamelToSnake(t *testing.T) {
 	}
 }
 
+func TestCamelToLowerCamel(t *testing.T) {
+	for i, test := range []struct {
+		In, Out string
+	}{
+		{"", ""},
+		{"A", "a"},
+		{"SimpleExample", "simpleExample"},
+		{"internalField", "internalField"},
+
+		{"SomeHTTPStuff", "someHTTPStuff"},
+		{"WriteJSON", "writeJSON"},
+		{"HTTP2Server", "http2Server"},
+
+		{"JSONHTTPRPCServer", "jsonhttprpcServer"}, // nothing can be done here without a dictionary
+	} {
+		got := lowerFirst(test.In)
+		if got != test.Out {
+			t.Errorf("[%d] lowerFirst(%s) = %s; want %s", i, test.In, got, test.Out)
+		}
+	}
+}
+
 func TestJoinFunctionNameParts(t *testing.T) {
 	for i, test := range []struct {
 		keepFirst bool


### PR DESCRIPTION
Adds the `--lower-camel-case` option to name fields in `lowerCamelCase` instead of `UpperCamelCase`.
Obviously you can't do this normally in the structs as fields starting with a lowercase letter are private and cannot be seen.