### PR TITLE
Get rid of unused isNumeric() function

### DIFF
--- a/gen/generator.go
+++ b/gen/generator.go
@@ -390,9 +390,6 @@ func isUpper(b byte) bool {
 	return b >= 65 && b <= 90
 }
 
-func isNumeric(b byte) bool {
-	return b >= 48 && b <= 57
-}
 // convert HTTPRestClient to httpRestClient
 func lowerFirst(s string) string {
 	if s == "" {


### PR DESCRIPTION
I put it in when adding the feature in my last PR but didn't end up using it, so removing it in this PR