### PR TITLE
add UseNumber option to Lexer for compatibility with encoding/json

### DIFF
--- a/jlexer/lexer.go
+++ b/jlexer/lexer.go
@@ -6,6 +6,7 @@ package jlexer
 
 import (
 	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -47,6 +48,8 @@ type Lexer struct {
 	firstElement bool // Whether current element is the first in array or an object.
 	wantSep      byte // A comma or a colon character, which need to occur before a token.
 
+	// UseNumber causes the Lexer to unmarshal a number into an interface{} as a json.Number instead of a float64.
+	UseNumber         bool
 	UseMultipleErrors bool          // If we want to use multiple errors.
 	fatalError        error         // Fatal error occurred during lexing. It is usually a syntax error.
 	multipleErrors    []*LexerError // Semantic errors occurred during lexing. Marshalling will be continued after finding this errors.
@@ -1009,6 +1012,15 @@ func (r *Lexer) Float64() float64 {
 	return n
 }
 
+func (r *Lexer) Number() json.Number {
+	s := r.number()
+	if !r.Ok() {
+		return json.Number("0")
+	}
+
+	return json.Number(s)
+}
+
 func (r *Lexer) Error() error {
 	return r.fatalError
 }
@@ -1056,6 +1068,9 @@ func (r *Lexer) Interface() interface{} {
 	case tokenString:
 		return r.String()
 	case tokenNumber:
+		if r.UseNumber {
+			return r.Number()
+		}
 		return r.Float64()
 	case tokenBool:
 		return r.Bool()

--- a/jlexer/lexer_test.go
+++ b/jlexer/lexer_test.go
@@ -2,6 +2,7 @@ package jlexer
 
 import (
 	"bytes"
+	"encoding/json"
 	"reflect"
 	"testing"
 )
@@ -24,9 +25,9 @@ func TestString(t *testing.T) {
 
 		{toParse: `"test"junk`, want: "test"},
 
-		{toParse: `5`, wantError: true},        // not a string
-		{toParse: `"\x"`, wantError: true},     // invalid escape
-		{toParse: `"\ud800"`, want: "�"},      // invalid utf-8 char; return replacement char
+		{toParse: `5`, wantError: true},    	// not a string
+		{toParse: `"\x"`, wantError: true}, 	// invalid escape
+		{toParse: `"\ud800"`, want: "�"},   	// invalid utf-8 char; return replacement char
 	} {
 		l := Lexer{Data: []byte(test.toParse)}
 
@@ -186,11 +187,13 @@ func TestInterface(t *testing.T) {
 		toParse   string
 		want      interface{}
 		wantError bool
+		useNumber bool
 	}{
 		{toParse: "null", want: nil},
 		{toParse: "true", want: true},
 		{toParse: `"a"`, want: "a"},
 		{toParse: "5", want: float64(5)},
+		{toParse: "5", want: json.Number("5"), useNumber: true},
 
 		{toParse: `{}`, want: map[string]interface{}{}},
 		{toParse: `[]`, want: []interface{}(nil)},
@@ -211,7 +214,7 @@ func TestInterface(t *testing.T) {
 		{toParse: `[1  2]`, wantError: true},
 		{toParse: `[,]`, wantError: true},
 	} {
-		l := Lexer{Data: []byte(test.toParse)}
+		l := Lexer{Data: []byte(test.toParse), UseNumber: test.useNumber}
 
 		got := l.Interface()
 		if !reflect.DeepEqual(got, test.want) {

--- a/tests/basic_test.go
+++ b/tests/basic_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/mailru/easyjson"
 	"github.com/mailru/easyjson/jwriter"
+	"github.com/mailru/easyjson/jlexer"
 )
 
 type testType interface {
@@ -218,5 +219,17 @@ func TestUnmarshalStructWithEmbeddedPtrStruct(t *testing.T) {
 	}
 	if !reflect.DeepEqual(s, structWithInterfaceValueFilled) {
 		t.Errorf("easyjson.Unmarshal() = %#v; want %#v", s, structWithInterfaceValueFilled)
+	}
+}
+
+func TestUnmarshalStructWithJSONNumber(t *testing.T) {
+	var s = StructWithInterface{}
+	l := jlexer.Lexer{Data: []byte(structWithInterfaceNumberString), UseNumber: true}
+	s.UnmarshalEasyJSON(&l)
+	if err := l.Error(); err != nil {
+		t.Errorf("easyjson.Unmarshal() error: %v", err)
+	}
+	if !reflect.DeepEqual(s, structWithInterfaceNumberValue) {
+		t.Errorf("easyjson.Unmarshal() = %#v; want %#v", s, structWithInterfaceNumberValue)
 	}
 }

--- a/tests/data.go
+++ b/tests/data.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"time"
 
+	"encoding/json"
 	"github.com/mailru/easyjson"
 	"github.com/mailru/easyjson/opt"
 )
@@ -692,3 +693,5 @@ type EmbeddedStruct struct {
 
 var structWithInterfaceString = `{"f1":1,"f2":{"f1":11,"f2":"22"},"f3":"3"}`
 var structWithInterfaceValueFilled = StructWithInterface{1, &EmbeddedStruct{11, "22"}, "3"}
+var structWithInterfaceNumberString = `{"f2": 3.141}`
+var structWithInterfaceNumberValue = StructWithInterface{Field2: json.Number("3.141")}


### PR DESCRIPTION
When `UseNumber` is `true` on an instance of `jlexer.Lexer` will unmarshal a number into an `interface` as `json.Number` rather than `float64`.

For example, the following struct

```go
type Variant struct {
    Val interface{}
}
```

and JSON

```json
{ "Val": 1.25 }
```

will unmarshal a `json.Number` into the `Val` field when `UseNumber` is `true`