### PR TITLE
Update parser_windows.go

### DIFF
--- a/parser/parser_windows.go
+++ b/parser/parser_windows.go
@@ -4,15 +4,18 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"path/filepath"
 	"strings"
 )
 
 func normalizePath(path string) string {
-	return strings.Replace(path, "\\", "/", -1)
+	// use lower case, as Windows file systems will almost always be case insensitive 
+	return strings.ToLower(strings.Replace(path, "\\", "/", -1))
 }
 
 func getPkgPath(fname string, isDir bool) (string, error) {
-	if !path.IsAbs(fname) {
+	// path.IsAbs doesn't work properly on Windows; use filepath.IsAbs instead
+	if !filepath.IsAbs(fname) {
 		pwd, err := os.Getwd()
 		if err != nil {
 			return "", err


### PR DESCRIPTION
Use filepath.IsAbs instead of path.IsAbs for Windows; convert paths to lowercase when normalizing them

See https://github.com/mailru/easyjson/issues/129