### PR TITLE
Trim whitespace around build tags

### DIFF
--- a/easyjson/main.go
+++ b/easyjson/main.go
@@ -54,8 +54,13 @@ func generate(fname string) (err error) {
 		outName = *specifiedName
 	}
 
+	var trimmedBuildTags string
+	if *buildTags != "" {
+		trimmedBuildTags = strings.TrimSpace(*buildTags)
+	}
+
 	g := bootstrap.Generator{
-		BuildTags:       *buildTags,
+		BuildTags:       trimmedBuildTags,
 		PkgPath:         p.PkgPath,
 		PkgName:         p.PkgName,
 		Types:           p.StructNames,


### PR DESCRIPTION
This commit trims whitespace around the build tags specified on the
command line in order that invocations such as:

```
easyjson -build_tags linux
```

generate the correct:

```
// +build linux
```

rather than adding additional whitespace, giving

```
// +build  linux
```