### PR TITLE
Detect GOPATH if not specified in $GOPATH

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -4,6 +4,7 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
+	"os/exec"
 	"strings"
 )
 
@@ -88,4 +89,9 @@ func (p *Parser) Parse(fname string, isDir bool) error {
 		ast.Walk(&visitor{Parser: p}, f)
 	}
 	return nil
+}
+
+func getDefaultGoPath() (string, error) {
+	output, err := exec.Command("go", "env", "GOPATH").Output()
+	return string(output), err
 }

--- a/parser/parser_unix.go
+++ b/parser/parser_unix.go
@@ -18,6 +18,15 @@ func getPkgPath(fname string, isDir bool) (string, error) {
 		fname = path.Join(pwd, fname)
 	}
 
+	gopath := os.Getenv("GOPATH")
+	if gopath == "" {
+		var err error
+		gopath, err = getDefaultGoPath()
+		if err != nil {
+			return "", fmt.Errorf("cannot determine GOPATH: %s", err)
+		}
+	}
+
 	for _, p := range strings.Split(os.Getenv("GOPATH"), ":") {
 		prefix := path.Join(p, "src") + "/"
 		if rel := strings.TrimPrefix(fname, prefix); rel != fname {

--- a/parser/parser_windows.go
+++ b/parser/parser_windows.go
@@ -22,6 +22,15 @@ func getPkgPath(fname string, isDir bool) (string, error) {
 
 	fname = normalizePath(fname)
 
+	gopath := os.Getenv("GOPATH")
+	if gopath == "" {
+		var err error
+		gopath, err = getDefaultGoPath()
+		if err != nil {
+			return "", fmt.Errorf("cannot determine GOPATH: %s", err)
+		}
+	}
+
 	for _, p := range strings.Split(os.Getenv("GOPATH"), ";") {
 		prefix := path.Join(normalizePath(p), "src") + "/"
 		if rel := strings.TrimPrefix(fname, prefix); rel != fname {


### PR DESCRIPTION
It is no longer required to have the GOPATH environment variable set - it now defaults to ~/go, but irrespective of whether the value is the default or not it can be found in the standard output of `go env GOPATH`.

This commit uses that value if the GOPATH environment variable is not set.