### PR TITLE
Add jsoniter to benchmarks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: go
 
 go:
-        - tip
+  - tip
 install:
-        - go get github.com/ugorji/go/codec
-        - go get github.com/pquerna/ffjson/fflib/v1
-        - go get github.com/golang/lint/golint
+  - go get github.com/ugorji/go/codec
+  - go get github.com/pquerna/ffjson/fflib/v1
+  - go get github.com/json-iterator/go
+  - go get github.com/golang/lint/golint

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ export GOPATH
 
 all: test
 
-.root/src/$(PKG): 	
+.root/src/$(PKG):
 	mkdir -p $@
 	for i in $$PWD/* ; do ln -s $$i $@/`basename $$i` ; done 
 
@@ -45,6 +45,7 @@ test: generate root
 bench-other: generate root
 	@go test -benchmem -bench . $(PKG)/benchmark
 	@go test -benchmem -tags use_ffjson -bench . $(PKG)/benchmark
+	@go test -benchmem -tags use_jsoniter -bench . $(PKG)/benchmark
 	@go test -benchmem -tags use_codec -bench . $(PKG)/benchmark
 
 bench-python:

--- a/benchmark/jsoniter_test.go
+++ b/benchmark/jsoniter_test.go
@@ -1,27 +1,28 @@
-// +build !use_easyjson,!use_ffjson,!use_codec,!use_jsoniter
+// +build use_jsoniter
 
 package benchmark
 
 import (
-	"encoding/json"
 	"testing"
+
+	jsoniter "github.com/json-iterator/go"
 )
 
-func BenchmarkStd_Unmarshal_M(b *testing.B) {
+func BenchmarkJI_Unmarshal_M(b *testing.B) {
 	b.SetBytes(int64(len(largeStructText)))
 	for i := 0; i < b.N; i++ {
 		var s LargeStruct
-		err := json.Unmarshal(largeStructText, &s)
+		err := jsoniter.Unmarshal(largeStructText, &s)
 		if err != nil {
 			b.Error(err)
 		}
 	}
 }
 
-func BenchmarkStd_Unmarshal_S(b *testing.B) {
+func BenchmarkJI_Unmarshal_S(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		var s Entities
-		err := json.Unmarshal(smallStructText, &s)
+		err := jsoniter.Unmarshal(smallStructText, &s)
 		if err != nil {
 			b.Error(err)
 		}
@@ -29,10 +30,10 @@ func BenchmarkStd_Unmarshal_S(b *testing.B) {
 	b.SetBytes(int64(len(smallStructText)))
 }
 
-func BenchmarkStd_Marshal_M(b *testing.B) {
+func BenchmarkJI_Marshal_M(b *testing.B) {
 	var l int64
 	for i := 0; i < b.N; i++ {
-		data, err := json.Marshal(&largeStructData)
+		data, err := jsoniter.Marshal(&largeStructData)
 		if err != nil {
 			b.Error(err)
 		}
@@ -41,10 +42,10 @@ func BenchmarkStd_Marshal_M(b *testing.B) {
 	b.SetBytes(l)
 }
 
-func BenchmarkStd_Marshal_L(b *testing.B) {
+func BenchmarkJI_Marshal_L(b *testing.B) {
 	var l int64
 	for i := 0; i < b.N; i++ {
-		data, err := json.Marshal(&xlStructData)
+		data, err := jsoniter.Marshal(&xlStructData)
 		if err != nil {
 			b.Error(err)
 		}
@@ -53,11 +54,11 @@ func BenchmarkStd_Marshal_L(b *testing.B) {
 	b.SetBytes(l)
 }
 
-func BenchmarkStd_Marshal_M_Parallel(b *testing.B) {
+func BenchmarkJI_Marshal_M_Parallel(b *testing.B) {
 	var l int64
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
-			data, err := json.Marshal(&largeStructData)
+			data, err := jsoniter.Marshal(&largeStructData)
 			if err != nil {
 				b.Error(err)
 			}
@@ -67,11 +68,11 @@ func BenchmarkStd_Marshal_M_Parallel(b *testing.B) {
 	b.SetBytes(l)
 }
 
-func BenchmarkStd_Marshal_L_Parallel(b *testing.B) {
+func BenchmarkJI_Marshal_L_Parallel(b *testing.B) {
 	var l int64
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
-			data, err := json.Marshal(&xlStructData)
+			data, err := jsoniter.Marshal(&xlStructData)
 			if err != nil {
 				b.Error(err)
 			}
@@ -81,10 +82,10 @@ func BenchmarkStd_Marshal_L_Parallel(b *testing.B) {
 	b.SetBytes(l)
 }
 
-func BenchmarkStd_Marshal_S(b *testing.B) {
+func BenchmarkJI_Marshal_S(b *testing.B) {
 	var l int64
 	for i := 0; i < b.N; i++ {
-		data, err := json.Marshal(&smallStructData)
+		data, err := jsoniter.Marshal(&smallStructData)
 		if err != nil {
 			b.Error(err)
 		}
@@ -93,11 +94,11 @@ func BenchmarkStd_Marshal_S(b *testing.B) {
 	b.SetBytes(l)
 }
 
-func BenchmarkStd_Marshal_S_Parallel(b *testing.B) {
+func BenchmarkJI_Marshal_S_Parallel(b *testing.B) {
 	var l int64
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
-			data, err := json.Marshal(&smallStructData)
+			data, err := jsoniter.Marshal(&smallStructData)
 			if err != nil {
 				b.Error(err)
 			}
@@ -107,8 +108,8 @@ func BenchmarkStd_Marshal_S_Parallel(b *testing.B) {
 	b.SetBytes(l)
 }
 
-func BenchmarkStd_Marshal_M_ToWriter(b *testing.B) {
-	enc := json.NewEncoder(&DummyWriter{})
+func BenchmarkJI_Marshal_M_ToWriter(b *testing.B) {
+	enc := jsoniter.NewEncoder(&DummyWriter{})
 	for i := 0; i < b.N; i++ {
 		err := enc.Encode(&largeStructData)
 		if err != nil {


### PR DESCRIPTION
I wanted to check how easyjson works, compared to [json-iterator/go](https://github.com/json-iterator/go) aka jsoniter, which looks like an attractive replacement for a standard `encoding/json`.

According to jsoniter's own [benchmarks](https://github.com/json-iterator/go-benchmark), it performs on the same level with easyjson, while doesn't require code generation.

Below are the results of running benchmarks on my MacBook Pro 2016 (2 GHz Intel Core i5) with Go 1.9.

```
% go test -benchmem -tags use_easyjson -bench . github.com/mailru/easyjson/benchmark
goos: darwin
goarch: amd64
pkg: github.com/mailru/easyjson/benchmark
BenchmarkEJ_Unmarshal_M-4                   	   30000	     49584 ns/op	 262.66 MB/s	    9792 B/op	     128 allocs/op
BenchmarkEJ_Unmarshal_S-4                   	 2000000	       701 ns/op	 116.90 MB/s	     128 B/op	       3 allocs/op
BenchmarkEJ_Marshal_M-4                     	  100000	     21303 ns/op	 419.98 MB/s	   10344 B/op	      10 allocs/op
BenchmarkEJ_Marshal_L-4                     	    2000	   1029839 ns/op	 434.45 MB/s	  458113 B/op	      28 allocs/op
BenchmarkEJ_Marshal_L_ToWriter-4            	    2000	    910851 ns/op	 491.20 MB/s	    2798 B/op	      24 allocs/op
BenchmarkEJ_Marshal_M_Parallel-4            	  200000	     11353 ns/op	1147.13 MB/s	   10313 B/op	       9 allocs/op
BenchmarkEJ_Marshal_M_ToWriter-4            	  100000	     19179 ns/op	 466.49 MB/s	     739 B/op	       8 allocs/op
BenchmarkEJ_Marshal_M_ToWriter_Parallel-4   	  200000	      9655 ns/op	 926.62 MB/s	     746 B/op	       8 allocs/op
BenchmarkEJ_Marshal_L_Parallel-4            	    2000	    608340 ns/op	 735.46 MB/s	  553583 B/op	      35 allocs/op
BenchmarkEJ_Marshal_L_ToWriter_Parallel-4   	    3000	    473716 ns/op	 944.47 MB/s	    3634 B/op	      24 allocs/op
BenchmarkEJ_Marshal_S-4                     	 5000000	       289 ns/op	 280.21 MB/s	     128 B/op	       1 allocs/op
BenchmarkEJ_Marshal_S_Parallel-4            	10000000	       180 ns/op	 449.65 MB/s	     128 B/op	       1 allocs/op
PASS
ok  	github.com/mailru/easyjson/benchmark	23.605s

% make bench-other
goos: darwin
goarch: amd64
pkg: github.com/mailru/easyjson/benchmark
BenchmarkStd_Unmarshal_M-4          	    5000	    269116 ns/op	  48.40 MB/s	   10272 B/op	     218 allocs/op
BenchmarkStd_Unmarshal_S-4          	  500000	      3215 ns/op	  25.50 MB/s	     768 B/op	      14 allocs/op
BenchmarkStd_Marshal_M-4            	   30000	     39912 ns/op	 224.17 MB/s	   21712 B/op	       8 allocs/op
BenchmarkStd_Marshal_L-4            	    1000	   1870726 ns/op	 239.16 MB/s	 1217056 B/op	      14 allocs/op
BenchmarkStd_Marshal_M_Parallel-4   	  100000	     18767 ns/op	 476.73 MB/s	   21712 B/op	       8 allocs/op
BenchmarkStd_Marshal_L_Parallel-4   	    2000	    968150 ns/op	 462.13 MB/s	 1217060 B/op	      14 allocs/op
BenchmarkStd_Marshal_S-4            	 2000000	       839 ns/op	  96.48 MB/s	     320 B/op	       2 allocs/op
BenchmarkStd_Marshal_S_Parallel-4   	 3000000	       442 ns/op	 183.17 MB/s	     320 B/op	       2 allocs/op
BenchmarkStd_Marshal_M_ToWriter-4   	   50000	     35124 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	github.com/mailru/easyjson/benchmark	17.276s
goos: darwin
goarch: amd64
pkg: github.com/mailru/easyjson/benchmark
BenchmarkFF_Unmarshal_M-4               	   20000	     68031 ns/op	 191.44 MB/s	    9986 B/op	     141 allocs/op
BenchmarkFF_Unmarshal_S-4               	 1000000	      1515 ns/op	  54.10 MB/s	     504 B/op	      10 allocs/op
BenchmarkFF_Marshal_M-4                 	   50000	     27140 ns/op	 329.65 MB/s	   21271 B/op	     151 allocs/op
BenchmarkFF_Marshal_S-4                 	 2000000	       705 ns/op	 114.84 MB/s	     400 B/op	       5 allocs/op
BenchmarkFF_Marshal_M_Pool-4            	   50000	     24433 ns/op	 366.17 MB/s	    4869 B/op	     150 allocs/op
BenchmarkFF_Marshal_L-4                 	    1000	   1287493 ns/op	 347.50 MB/s	  823997 B/op	    7215 allocs/op
BenchmarkFF_Marshal_L_Pool-4            	    1000	   1261240 ns/op	 354.74 MB/s	  826479 B/op	    7217 allocs/op
BenchmarkFF_Marshal_L_Pool_Parallel-4   	    1000	   1251607 ns/op	 357.47 MB/s	  825234 B/op	    7217 allocs/op
BenchmarkFF_Marshal_M_Pool_Parallel-4   	  100000	     12590 ns/op	 710.59 MB/s	    4916 B/op	     150 allocs/op
BenchmarkFF_Marshal_S_Pool-4            	 3000000	       549 ns/op	 147.46 MB/s	     144 B/op	       4 allocs/op
BenchmarkFF_Marshal_S_Pool_Parallel-4   	 5000000	       303 ns/op	 267.11 MB/s	     144 B/op	       4 allocs/op
BenchmarkFF_Marshal_S_Parallel-4        	 3000000	       455 ns/op	 177.91 MB/s	     400 B/op	       5 allocs/op
BenchmarkFF_Marshal_M_Parallel-4        	  100000	     14269 ns/op	 627.02 MB/s	   21323 B/op	     151 allocs/op
BenchmarkFF_Marshal_L_Parallel-4        	    2000	    718085 ns/op	 623.06 MB/s	 1039031 B/op	    7230 allocs/op
PASS
ok  	github.com/mailru/easyjson/benchmark	23.554s
goos: darwin
goarch: amd64
pkg: github.com/mailru/easyjson/benchmark
BenchmarkJI_Unmarshal_M-4          	   20000	     61910 ns/op	 210.37 MB/s	   10000 B/op	     176 allocs/op
BenchmarkJI_Unmarshal_S-4          	 1000000	      1182 ns/op	  69.37 MB/s	     480 B/op	      10 allocs/op
BenchmarkJI_Marshal_M-4            	   50000	     25193 ns/op	 355.13 MB/s	    9525 B/op	       4 allocs/op
BenchmarkJI_Marshal_L-4            	    1000	   1252162 ns/op	 357.31 MB/s	  452443 B/op	     102 allocs/op
BenchmarkJI_Marshal_M_Parallel-4   	  100000	     12116 ns/op	 738.44 MB/s	    9525 B/op	       4 allocs/op
BenchmarkJI_Marshal_L_Parallel-4   	    2000	    624088 ns/op	 716.90 MB/s	  452448 B/op	     102 allocs/op
BenchmarkJI_Marshal_S-4            	 2000000	       609 ns/op	 133.00 MB/s	     112 B/op	       2 allocs/op
BenchmarkJI_Marshal_S_Parallel-4   	 3000000	       448 ns/op	 180.78 MB/s	     112 B/op	       2 allocs/op
BenchmarkJI_Marshal_M_ToWriter-4   	   50000	     24004 ns/op	      53 B/op	       3 allocs/op
PASS
ok  	github.com/mailru/easyjson/benchmark	13.788s
goos: darwin
goarch: amd64
pkg: github.com/mailru/easyjson/benchmark
BenchmarkCodec_Unmarshal_M-4                	   10000	    111570 ns/op	 116.73 MB/s	   19296 B/op	     434 allocs/op
BenchmarkCodec_Unmarshal_S-4                	 1000000	      1353 ns/op	  60.61 MB/s	     336 B/op	       7 allocs/op
BenchmarkCodec_Marshal_S-4                  	 2000000	       798 ns/op	 101.49 MB/s	     304 B/op	       3 allocs/op
BenchmarkCodec_Marshal_M-4                  	   30000	     42489 ns/op	 210.57 MB/s	   31552 B/op	      17 allocs/op
BenchmarkCodec_Marshal_L-4                  	     500	   2312657 ns/op	 193.46 MB/s	 2512849 B/op	     474 allocs/op
BenchmarkCodec_Marshal_S_Reuse-4            	 2000000	       707 ns/op	 114.45 MB/s	      48 B/op	       1 allocs/op
BenchmarkCodec_Marshal_M_Reuse-4            	   50000	     38559 ns/op	 232.03 MB/s	    1152 B/op	       9 allocs/op
BenchmarkCodec_Marshal_L_Reuse-4            	    1000	   1895156 ns/op	 236.08 MB/s	   60199 B/op	     451 allocs/op
BenchmarkCodec_Marshal_S_Parallel-4         	 3000000	       496 ns/op	 163.05 MB/s	     304 B/op	       3 allocs/op
BenchmarkCodec_Marshal_M_Parallel-4         	   50000	     25732 ns/op	 347.69 MB/s	   31552 B/op	      17 allocs/op
BenchmarkCodec_Marshal_L_Parallel-4         	    1000	   1631751 ns/op	 274.19 MB/s	 2512852 B/op	     474 allocs/op
BenchmarkCodec_Marshal_S_Parallel_Reuse-4   	 5000000	       352 ns/op	 229.60 MB/s	      48 B/op	       1 allocs/op
BenchmarkCodec_Marshal_M_Parallel_Reuse-4   	  100000	     18766 ns/op	 476.75 MB/s	    1153 B/op	       9 allocs/op
BenchmarkCodec_Marshal_L_Parallel_Reuse-4   	    2000	    948391 ns/op	 471.76 MB/s	   62656 B/op	     451 allocs/op
PASS
ok  	github.com/mailru/easyjson/benchmark	26.203s
```