### PR TITLE
[Bug Fix] Handle errors when generating encoder/decoder for nested structures

### DIFF
--- a/gen/decoder.go
+++ b/gen/decoder.go
@@ -127,7 +127,9 @@ func (g *Generator) genTypeDecoderNoCheck(t reflect.Type, out string, tags field
 			fmt.Fprintln(g.out, ws+"  for !in.IsDelim(']') {")
 			fmt.Fprintln(g.out, ws+"    var "+tmpVar+" "+g.getType(elem))
 
-			g.genTypeDecoder(elem, tmpVar, tags, indent+2)
+			if err := g.genTypeDecoder(elem, tmpVar, tags, indent+2); err != nil {
+				return err
+			}
 
 			fmt.Fprintln(g.out, ws+"    "+out+" = append("+out+", "+tmpVar+")")
 			fmt.Fprintln(g.out, ws+"    in.WantComma()")
@@ -159,7 +161,9 @@ func (g *Generator) genTypeDecoderNoCheck(t reflect.Type, out string, tags field
 			fmt.Fprintln(g.out, ws+"  for !in.IsDelim(']') {")
 			fmt.Fprintln(g.out, ws+"    if "+iterVar+" < "+fmt.Sprint(length)+" {")
 
-			g.genTypeDecoder(elem, out+"["+iterVar+"]", tags, indent+3)
+			if err := g.genTypeDecoder(elem, out+"["+iterVar+"]", tags, indent+3); err != nil {
+				return err
+			}
 
 			fmt.Fprintln(g.out, ws+"      "+iterVar+"++")
 			fmt.Fprintln(g.out, ws+"    } else {")
@@ -186,7 +190,9 @@ func (g *Generator) genTypeDecoderNoCheck(t reflect.Type, out string, tags field
 		fmt.Fprintln(g.out, ws+"    "+out+" = new("+g.getType(t.Elem())+")")
 		fmt.Fprintln(g.out, ws+"  }")
 
-		g.genTypeDecoder(t.Elem(), "*"+out, tags, indent+1)
+		if err := g.genTypeDecoder(t.Elem(), "*"+out, tags, indent+1); err != nil {
+			return err
+		}
 
 		fmt.Fprintln(g.out, ws+"}")
 
@@ -213,7 +219,9 @@ func (g *Generator) genTypeDecoderNoCheck(t reflect.Type, out string, tags field
 		fmt.Fprintln(g.out, ws+"    in.WantColon()")
 		fmt.Fprintln(g.out, ws+"    var "+tmpVar+" "+g.getType(elem))
 
-		g.genTypeDecoder(elem, tmpVar, tags, indent+2)
+		if err := g.genTypeDecoder(elem, tmpVar, tags, indent+2); err != nil {
+			return err
+		}
 
 		fmt.Fprintln(g.out, ws+"    ("+out+")[key] = "+tmpVar)
 		fmt.Fprintln(g.out, ws+"    in.WantComma()")

--- a/gen/encoder.go
+++ b/gen/encoder.go
@@ -137,7 +137,9 @@ func (g *Generator) genTypeEncoderNoCheck(t reflect.Type, in string, tags fieldT
 			fmt.Fprintln(g.out, ws+"      out.RawByte(',')")
 			fmt.Fprintln(g.out, ws+"    }")
 
-			g.genTypeEncoder(elem, vVar, tags, indent+2)
+			if err := g.genTypeEncoder(elem, vVar, tags, indent+2); err != nil {
+				return err
+			}
 
 			fmt.Fprintln(g.out, ws+"  }")
 			fmt.Fprintln(g.out, ws+"  out.RawByte(']')")
@@ -157,7 +159,9 @@ func (g *Generator) genTypeEncoderNoCheck(t reflect.Type, in string, tags fieldT
 			fmt.Fprintln(g.out, ws+"    out.RawByte(',')")
 			fmt.Fprintln(g.out, ws+"  }")
 
-			g.genTypeEncoder(elem, in+"["+iVar+"]", tags, indent+1)
+			if err := g.genTypeEncoder(elem, in+"["+iVar+"]", tags, indent+1); err != nil {
+				return err
+			}
 
 			fmt.Fprintln(g.out, ws+"}")
 			fmt.Fprintln(g.out, ws+"out.RawByte(']')")
@@ -174,7 +178,9 @@ func (g *Generator) genTypeEncoderNoCheck(t reflect.Type, in string, tags fieldT
 		fmt.Fprintln(g.out, ws+`  out.RawString("null")`)
 		fmt.Fprintln(g.out, ws+"} else {")
 
-		g.genTypeEncoder(t.Elem(), "*"+in, tags, indent+1)
+		if err := g.genTypeEncoder(t.Elem(), "*"+in, tags, indent+1); err != nil {
+			return err
+		}
 
 		fmt.Fprintln(g.out, ws+"}")
 
@@ -196,7 +202,9 @@ func (g *Generator) genTypeEncoderNoCheck(t reflect.Type, in string, tags fieldT
 		fmt.Fprintln(g.out, ws+"    out.String(string("+tmpVar+"Name))")
 		fmt.Fprintln(g.out, ws+"    out.RawByte(':')")
 
-		g.genTypeEncoder(t.Elem(), tmpVar+"Value", tags, indent+2)
+		if err := g.genTypeEncoder(t.Elem(), tmpVar+"Value", tags, indent+2); err != nil {
+			return err
+		}
 
 		fmt.Fprintln(g.out, ws+"  }")
 		fmt.Fprintln(g.out, ws+"  out.RawByte('}')")

--- a/tests/non_string_keyed_map_test.go
+++ b/tests/non_string_keyed_map_test.go
@@ -1,0 +1,44 @@
+package tests
+
+import (
+	"os"
+	"testing"
+
+	"github.com/mailru/easyjson/gen"
+)
+
+type IntMap map[int]string
+type IntMapSlice []IntMap
+type IntMapArray [2]IntMap
+type IntMapPtr *IntMap
+type IntMapMap map[string]IntMap
+
+func TestNonStringKeyedtMapEncoder(t *testing.T) {
+	f := "non_string_keyed_map_easyjson.go"
+	for _, test := range []struct {
+		Data interface{}
+	}{
+		{
+			Data: IntMap{},
+		},
+		{
+			Data: IntMapSlice{},
+		},
+		{
+			Data: IntMapArray{},
+		},
+		{
+			Data: IntMapPtr(nil),
+		},
+		{
+			Data: IntMapMap{},
+		},
+	} {
+		g := gen.NewGenerator(f)
+		g.Add(test.Data)
+		e := g.Run(os.Stdout)
+		if e == nil {
+			t.Errorf("generation for %#v should have errored", test.Data)
+		}
+	}
+}


### PR DESCRIPTION
When seeing an unsupported type (e.g., `map[int]string`), easyjson behaves correctly and exits with status code 1. However, if the unsupported type is nested (e.g., `map[string]map[int]string`), easyjson exits with status code 0 and generates invalid code silently, as mentioned in https://github.com/mailru/easyjson/issues/50. Below is an example:

```go
➜  easyjson git:(master) ✗ cat foo.go
package easyjson

//easyjson:json
type Foo map[string]map[int]string

➜  easyjson git:(master) ✗ ./.root/bin/easyjson foo.go && echo 'success'
success

➜  easyjson git:(master) ✗ cat foo_easyjson.go
...
func easyjsonE4de407aEncodeGithubComMailruEasyjson(out *jwriter.Writer, in Foo) {
	if in == nil && (out.Flags&jwriter.NilMapAsEmpty) == 0 {
		out.RawString(`null`)
	} else {
		out.RawByte('{')
		v2First := true
		for v2Name, v2Value := range in {
			if !v2First {
				out.RawByte(',')
			}
			v2First = false
			out.String(string(v2Name))
		  	out.RawByte(':') // value serialization missing 
		}
		out.RawByte('}')
	}
}
...
```

The reason is that error handling is missing at places like [here](https://github.com/mailru/easyjson/blob/master/gen/encoder.go#L199), [here](https://github.com/mailru/easyjson/blob/master/gen/encoder.go#L160), etc. 
This PR fixes https://github.com/mailru/easyjson/issues/50 and adds tests to verify generation fails for nested unsupported type.

```
➜  easyjson git:(lu.mk) ✗ ./.root/bin/easyjson foo.go && echo 'success'
map type int not supported: only string keys are allowed
exit status 1
Bootstrap failed: exit status 1
```