### PR TITLE
Feature: allow to unmarshal json.Number

### DIFF
--- a/gen/decoder.go
+++ b/gen/decoder.go
@@ -48,6 +48,10 @@ var primitiveStringDecoders = map[reflect.Kind]string{
 	reflect.Uint64: "in.Uint64Str()",
 }
 
+var customDecoders = map[string]string{
+	"json.Number":    "in.JsonNumber()",
+}
+
 // genTypeDecoder generates decoding code for the type t, but uses unmarshaler interface if implemented by t.
 func (g *Generator) genTypeDecoder(t reflect.Type, out string, tags fieldTags, indent int) error {
 	ws := strings.Repeat("  ", indent)
@@ -82,7 +86,10 @@ func (g *Generator) genTypeDecoder(t reflect.Type, out string, tags fieldTags, i
 func (g *Generator) genTypeDecoderNoCheck(t reflect.Type, out string, tags fieldTags, indent int) error {
 	ws := strings.Repeat("  ", indent)
 	// Check whether type is primitive, needs to be done after interface check.
-	if dec := primitiveStringDecoders[t.Kind()]; dec != "" && tags.asString {
+	if dec := customDecoders[t.String()]; dec != ""  {
+		fmt.Fprintln(g.out, ws+out+" = "+dec)
+		return nil
+	} else if dec := primitiveStringDecoders[t.Kind()]; dec != "" && tags.asString {
 		fmt.Fprintln(g.out, ws+out+" = "+g.getType(t)+"("+dec+")")
 		return nil
 	} else if dec := primitiveDecoders[t.Kind()]; dec != "" {

--- a/jlexer/lexer.go
+++ b/jlexer/lexer.go
@@ -6,6 +6,7 @@ package jlexer
 
 import (
 	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -1041,6 +1042,28 @@ func (r *Lexer) addNonfatalError(err *LexerError) {
 
 func (r *Lexer) GetNonFatalErrors() []*LexerError {
 	return r.multipleErrors
+}
+
+// JsonNumber fetches and json.Number from 'encoding/json' package.
+// Both int, float or string, contains them are valid values
+func (r *Lexer) JsonNumber() json.Number {
+	if r.token.kind == tokenUndef && r.Ok() {
+		r.FetchToken()
+	}
+	if !r.Ok() {
+		r.errInvalidToken("json.Number")
+		return json.Number("0")
+	}
+
+	switch r.token.kind {
+	case tokenString:
+		return json.Number(r.String())
+	case tokenNumber:
+		return json.Number(r.Raw())
+	default:
+		r.errSyntax()
+		return json.Number("0")
+	}
 }
 
 // Interface fetches an interface{} analogous to the 'encoding/json' package.


### PR DESCRIPTION
Both go native encoding/json json.Unmarshal and ffjson's UnmarshalJSON methods could unmarshal following json-encoded strings:
* `{"number": 10}`
* `{"number": "20"}`
to 
```
.... struct {
  Number json.Number `json:"number"`
}
```
But easyjson got error on unmarshaling second json-encoded string.