### PR TITLE
fix problem with installation on 32-bit system 

### DIFF
--- a/benchmark/data.go
+++ b/benchmark/data.go
@@ -25,12 +25,12 @@ var smallStructData = Entities{
 type SearchMetadata struct {
 	CompletedIn float64 `json:"completed_in"`
 	Count       int     `json:"count"`
-	MaxID       int     `json:"max_id"`
+	MaxID       int64   `json:"max_id"`
 	MaxIDStr    string  `json:"max_id_str"`
 	NextResults string  `json:"next_results"`
 	Query       string  `json:"query"`
 	RefreshURL  string  `json:"refresh_url"`
-	SinceID     int     `json:"since_id"`
+	SinceID     int64   `json:"since_id"`
 	SinceIDStr  string  `json:"since_id_str"`
 }
 

--- a/tests/data.go
+++ b/tests/data.go
@@ -89,10 +89,10 @@ var primitiveTypesString = "{" +
 	`"Int32":` + fmt.Sprint(math.MinInt32) + `,` +
 	`"Int64":` + fmt.Sprint(int64(math.MinInt64)) + `,` +
 
-	`"Uint":` + fmt.Sprint(math.MaxUint32) + `,` +
+	`"Uint":` + fmt.Sprint(uint32(math.MaxUint32)) + `,` +
 	`"Uint8":` + fmt.Sprint(math.MaxUint8) + `,` +
 	`"Uint16":` + fmt.Sprint(math.MaxUint16) + `,` +
-	`"Uint32":` + fmt.Sprint(math.MaxUint32) + `,` +
+	`"Uint32":` + fmt.Sprint(uint32(math.MaxUint32)) + `,` +
 	`"Uint64":` + fmt.Sprint(uint64(math.MaxUint64)) + `,` +
 
 	`"IntString":"` + fmt.Sprint(math.MinInt32) + `",` +
@@ -101,10 +101,10 @@ var primitiveTypesString = "{" +
 	`"Int32String":"` + fmt.Sprint(math.MinInt32) + `",` +
 	`"Int64String":"` + fmt.Sprint(int64(math.MinInt64)) + `",` +
 
-	`"UintString":"` + fmt.Sprint(math.MaxUint32) + `",` +
+	`"UintString":"` + fmt.Sprint(uint32(math.MaxUint32)) + `",` +
 	`"Uint8String":"` + fmt.Sprint(math.MaxUint8) + `",` +
 	`"Uint16String":"` + fmt.Sprint(math.MaxUint16) + `",` +
-	`"Uint32String":"` + fmt.Sprint(math.MaxUint32) + `",` +
+	`"Uint32String":"` + fmt.Sprint(uint32(math.MaxUint32)) + `",` +
 	`"Uint64String":"` + fmt.Sprint(uint64(math.MaxUint64)) + `",` +
 
 	`"Float32":` + fmt.Sprint(1.5) + `,` +
@@ -192,10 +192,10 @@ var namedPrimitiveTypesString = "{" +
 	`"Int32":` + fmt.Sprint(math.MinInt32) + `,` +
 	`"Int64":` + fmt.Sprint(int64(math.MinInt64)) + `,` +
 
-	`"Uint":` + fmt.Sprint(math.MaxUint32) + `,` +
+	`"Uint":` + fmt.Sprint(uint32(math.MaxUint32)) + `,` +
 	`"Uint8":` + fmt.Sprint(math.MaxUint8) + `,` +
 	`"Uint16":` + fmt.Sprint(math.MaxUint16) + `,` +
-	`"Uint32":` + fmt.Sprint(math.MaxUint32) + `,` +
+	`"Uint32":` + fmt.Sprint(uint32(math.MaxUint32)) + `,` +
 	`"Uint64":` + fmt.Sprint(uint64(math.MaxUint64)) + `,` +
 
 	`"Float32":` + fmt.Sprint(1.5) + `,` +
@@ -570,7 +570,7 @@ type DeepNest struct {
 
 var deepNestValue = DeepNest{
 	SliceMap: map[Str][]Str{
-		"testSliceMap": []Str{
+		"testSliceMap": {
 			"0",
 			"1",
 		},
@@ -579,39 +579,39 @@ var deepNestValue = DeepNest{
 		"testSliceMap1": []Str(nil),
 	},
 	SliceMap2: map[Str][]Str{
-		"testSliceMap2": []Str{},
+		"testSliceMap2": {},
 	},
 	NamedSliceMap: map[Str]NamedSlice{
-		"testNamedSliceMap": NamedSlice{
+		"testNamedSliceMap": {
 			"2",
 			"3",
 		},
 	},
 	NamedMapMap: map[Str]NamedMap{
-		"testNamedMapMap": NamedMap{
+		"testNamedMapMap": {
 			"key1": "value1",
 		},
 	},
 	MapSlice: []map[Str]Str{
-		map[Str]Str{
+		{
 			"testMapSlice": "someValue",
 		},
 	},
 	NamedSliceSlice: []NamedSlice{
-		NamedSlice{
+		{
 			"someValue1",
 			"someValue2",
 		},
-		NamedSlice{
+		{
 			"someValue3",
 			"someValue4",
 		},
 	},
 	NamedMapSlice: []NamedMap{
-		NamedMap{
+		{
 			"key2": "value2",
 		},
-		NamedMap{
+		{
 			"key3": "value3",
 		},
 	},

--- a/tests/data.go
+++ b/tests/data.go
@@ -570,7 +570,7 @@ type DeepNest struct {
 
 var deepNestValue = DeepNest{
 	SliceMap: map[Str][]Str{
-		"testSliceMap": {
+		"testSliceMap": []Str{
 			"0",
 			"1",
 		},
@@ -579,39 +579,39 @@ var deepNestValue = DeepNest{
 		"testSliceMap1": []Str(nil),
 	},
 	SliceMap2: map[Str][]Str{
-		"testSliceMap2": {},
+		"testSliceMap2": []Str{},
 	},
 	NamedSliceMap: map[Str]NamedSlice{
-		"testNamedSliceMap": {
+		"testNamedSliceMap": NamedSlice{
 			"2",
 			"3",
 		},
 	},
 	NamedMapMap: map[Str]NamedMap{
-		"testNamedMapMap": {
+		"testNamedMapMap": NamedMap{
 			"key1": "value1",
 		},
 	},
 	MapSlice: []map[Str]Str{
-		{
+		map[Str]Str{
 			"testMapSlice": "someValue",
 		},
 	},
 	NamedSliceSlice: []NamedSlice{
-		{
+		NamedSlice{
 			"someValue1",
 			"someValue2",
 		},
-		{
+		NamedSlice{
 			"someValue3",
 			"someValue4",
 		},
 	},
 	NamedMapSlice: []NamedMap{
-		{
+		NamedMap{
 			"key2": "value2",
 		},
-		{
+		NamedMap{
 			"key3": "value3",
 		},
 	},


### PR DESCRIPTION
Проблема возникала из-за того, что при передаче в fmt.Sprint() целочисленной константы с явно не указанным типом math.MaxUint32 рефлект, сидящий где-то глубоко в Sprint, определял тип константы как int (точнее говоря при присвоении пустому интерефейсу константы её тип указывался как int). При этом сама константа в в int могла и не помещаться, что и происходило в 32-bit системах.