### PR TITLE
Fix optional type wrapper's standard marshaler.

### DIFF
--- a/opt/gotemplate_Bool.go
+++ b/opt/gotemplate_Bool.go
@@ -51,7 +51,7 @@ func (v *Bool) UnmarshalEasyJSON(l *jlexer.Lexer) {
 }
 
 // MarshalJSON implements a standard json marshaler interface.
-func (v *Bool) MarshalJSON() ([]byte, error) {
+func (v Bool) MarshalJSON() ([]byte, error) {
 	w := jwriter.Writer{}
 	v.MarshalEasyJSON(&w)
 	return w.Buffer.BuildBytes(), w.Error
@@ -59,7 +59,7 @@ func (v *Bool) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements a standard json unmarshaler interface.
 func (v *Bool) UnmarshalJSON(data []byte) error {
-	l := jlexer.Lexer{}
+	l := jlexer.Lexer{Data: data}
 	v.UnmarshalEasyJSON(&l)
 	return l.Error()
 }

--- a/opt/gotemplate_Float32.go
+++ b/opt/gotemplate_Float32.go
@@ -51,7 +51,7 @@ func (v *Float32) UnmarshalEasyJSON(l *jlexer.Lexer) {
 }
 
 // MarshalJSON implements a standard json marshaler interface.
-func (v *Float32) MarshalJSON() ([]byte, error) {
+func (v Float32) MarshalJSON() ([]byte, error) {
 	w := jwriter.Writer{}
 	v.MarshalEasyJSON(&w)
 	return w.Buffer.BuildBytes(), w.Error
@@ -59,7 +59,7 @@ func (v *Float32) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements a standard json unmarshaler interface.
 func (v *Float32) UnmarshalJSON(data []byte) error {
-	l := jlexer.Lexer{}
+	l := jlexer.Lexer{Data: data}
 	v.UnmarshalEasyJSON(&l)
 	return l.Error()
 }

--- a/opt/gotemplate_Float64.go
+++ b/opt/gotemplate_Float64.go
@@ -51,7 +51,7 @@ func (v *Float64) UnmarshalEasyJSON(l *jlexer.Lexer) {
 }
 
 // MarshalJSON implements a standard json marshaler interface.
-func (v *Float64) MarshalJSON() ([]byte, error) {
+func (v Float64) MarshalJSON() ([]byte, error) {
 	w := jwriter.Writer{}
 	v.MarshalEasyJSON(&w)
 	return w.Buffer.BuildBytes(), w.Error
@@ -59,7 +59,7 @@ func (v *Float64) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements a standard json unmarshaler interface.
 func (v *Float64) UnmarshalJSON(data []byte) error {
-	l := jlexer.Lexer{}
+	l := jlexer.Lexer{Data: data}
 	v.UnmarshalEasyJSON(&l)
 	return l.Error()
 }

--- a/opt/gotemplate_Int.go
+++ b/opt/gotemplate_Int.go
@@ -51,7 +51,7 @@ func (v *Int) UnmarshalEasyJSON(l *jlexer.Lexer) {
 }
 
 // MarshalJSON implements a standard json marshaler interface.
-func (v *Int) MarshalJSON() ([]byte, error) {
+func (v Int) MarshalJSON() ([]byte, error) {
 	w := jwriter.Writer{}
 	v.MarshalEasyJSON(&w)
 	return w.Buffer.BuildBytes(), w.Error
@@ -59,7 +59,7 @@ func (v *Int) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements a standard json unmarshaler interface.
 func (v *Int) UnmarshalJSON(data []byte) error {
-	l := jlexer.Lexer{}
+	l := jlexer.Lexer{Data: data}
 	v.UnmarshalEasyJSON(&l)
 	return l.Error()
 }

--- a/opt/gotemplate_Int16.go
+++ b/opt/gotemplate_Int16.go
@@ -51,7 +51,7 @@ func (v *Int16) UnmarshalEasyJSON(l *jlexer.Lexer) {
 }
 
 // MarshalJSON implements a standard json marshaler interface.
-func (v *Int16) MarshalJSON() ([]byte, error) {
+func (v Int16) MarshalJSON() ([]byte, error) {
 	w := jwriter.Writer{}
 	v.MarshalEasyJSON(&w)
 	return w.Buffer.BuildBytes(), w.Error
@@ -59,7 +59,7 @@ func (v *Int16) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements a standard json unmarshaler interface.
 func (v *Int16) UnmarshalJSON(data []byte) error {
-	l := jlexer.Lexer{}
+	l := jlexer.Lexer{Data: data}
 	v.UnmarshalEasyJSON(&l)
 	return l.Error()
 }

--- a/opt/gotemplate_Int32.go
+++ b/opt/gotemplate_Int32.go
@@ -51,7 +51,7 @@ func (v *Int32) UnmarshalEasyJSON(l *jlexer.Lexer) {
 }
 
 // MarshalJSON implements a standard json marshaler interface.
-func (v *Int32) MarshalJSON() ([]byte, error) {
+func (v Int32) MarshalJSON() ([]byte, error) {
 	w := jwriter.Writer{}
 	v.MarshalEasyJSON(&w)
 	return w.Buffer.BuildBytes(), w.Error
@@ -59,7 +59,7 @@ func (v *Int32) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements a standard json unmarshaler interface.
 func (v *Int32) UnmarshalJSON(data []byte) error {
-	l := jlexer.Lexer{}
+	l := jlexer.Lexer{Data: data}
 	v.UnmarshalEasyJSON(&l)
 	return l.Error()
 }

--- a/opt/gotemplate_Int64.go
+++ b/opt/gotemplate_Int64.go
@@ -51,7 +51,7 @@ func (v *Int64) UnmarshalEasyJSON(l *jlexer.Lexer) {
 }
 
 // MarshalJSON implements a standard json marshaler interface.
-func (v *Int64) MarshalJSON() ([]byte, error) {
+func (v Int64) MarshalJSON() ([]byte, error) {
 	w := jwriter.Writer{}
 	v.MarshalEasyJSON(&w)
 	return w.Buffer.BuildBytes(), w.Error
@@ -59,7 +59,7 @@ func (v *Int64) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements a standard json unmarshaler interface.
 func (v *Int64) UnmarshalJSON(data []byte) error {
-	l := jlexer.Lexer{}
+	l := jlexer.Lexer{Data: data}
 	v.UnmarshalEasyJSON(&l)
 	return l.Error()
 }

--- a/opt/gotemplate_Int8.go
+++ b/opt/gotemplate_Int8.go
@@ -51,7 +51,7 @@ func (v *Int8) UnmarshalEasyJSON(l *jlexer.Lexer) {
 }
 
 // MarshalJSON implements a standard json marshaler interface.
-func (v *Int8) MarshalJSON() ([]byte, error) {
+func (v Int8) MarshalJSON() ([]byte, error) {
 	w := jwriter.Writer{}
 	v.MarshalEasyJSON(&w)
 	return w.Buffer.BuildBytes(), w.Error
@@ -59,7 +59,7 @@ func (v *Int8) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements a standard json unmarshaler interface.
 func (v *Int8) UnmarshalJSON(data []byte) error {
-	l := jlexer.Lexer{}
+	l := jlexer.Lexer{Data: data}
 	v.UnmarshalEasyJSON(&l)
 	return l.Error()
 }

--- a/opt/gotemplate_String.go
+++ b/opt/gotemplate_String.go
@@ -51,7 +51,7 @@ func (v *String) UnmarshalEasyJSON(l *jlexer.Lexer) {
 }
 
 // MarshalJSON implements a standard json marshaler interface.
-func (v *String) MarshalJSON() ([]byte, error) {
+func (v String) MarshalJSON() ([]byte, error) {
 	w := jwriter.Writer{}
 	v.MarshalEasyJSON(&w)
 	return w.Buffer.BuildBytes(), w.Error
@@ -59,7 +59,7 @@ func (v *String) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements a standard json unmarshaler interface.
 func (v *String) UnmarshalJSON(data []byte) error {
-	l := jlexer.Lexer{}
+	l := jlexer.Lexer{Data: data}
 	v.UnmarshalEasyJSON(&l)
 	return l.Error()
 }

--- a/opt/gotemplate_Uint.go
+++ b/opt/gotemplate_Uint.go
@@ -51,7 +51,7 @@ func (v *Uint) UnmarshalEasyJSON(l *jlexer.Lexer) {
 }
 
 // MarshalJSON implements a standard json marshaler interface.
-func (v *Uint) MarshalJSON() ([]byte, error) {
+func (v Uint) MarshalJSON() ([]byte, error) {
 	w := jwriter.Writer{}
 	v.MarshalEasyJSON(&w)
 	return w.Buffer.BuildBytes(), w.Error
@@ -59,7 +59,7 @@ func (v *Uint) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements a standard json unmarshaler interface.
 func (v *Uint) UnmarshalJSON(data []byte) error {
-	l := jlexer.Lexer{}
+	l := jlexer.Lexer{Data: data}
 	v.UnmarshalEasyJSON(&l)
 	return l.Error()
 }

--- a/opt/gotemplate_Uint16.go
+++ b/opt/gotemplate_Uint16.go
@@ -51,7 +51,7 @@ func (v *Uint16) UnmarshalEasyJSON(l *jlexer.Lexer) {
 }
 
 // MarshalJSON implements a standard json marshaler interface.
-func (v *Uint16) MarshalJSON() ([]byte, error) {
+func (v Uint16) MarshalJSON() ([]byte, error) {
 	w := jwriter.Writer{}
 	v.MarshalEasyJSON(&w)
 	return w.Buffer.BuildBytes(), w.Error
@@ -59,7 +59,7 @@ func (v *Uint16) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements a standard json unmarshaler interface.
 func (v *Uint16) UnmarshalJSON(data []byte) error {
-	l := jlexer.Lexer{}
+	l := jlexer.Lexer{Data: data}
 	v.UnmarshalEasyJSON(&l)
 	return l.Error()
 }

--- a/opt/gotemplate_Uint32.go
+++ b/opt/gotemplate_Uint32.go
@@ -51,7 +51,7 @@ func (v *Uint32) UnmarshalEasyJSON(l *jlexer.Lexer) {
 }
 
 // MarshalJSON implements a standard json marshaler interface.
-func (v *Uint32) MarshalJSON() ([]byte, error) {
+func (v Uint32) MarshalJSON() ([]byte, error) {
 	w := jwriter.Writer{}
 	v.MarshalEasyJSON(&w)
 	return w.Buffer.BuildBytes(), w.Error
@@ -59,7 +59,7 @@ func (v *Uint32) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements a standard json unmarshaler interface.
 func (v *Uint32) UnmarshalJSON(data []byte) error {
-	l := jlexer.Lexer{}
+	l := jlexer.Lexer{Data: data}
 	v.UnmarshalEasyJSON(&l)
 	return l.Error()
 }

--- a/opt/gotemplate_Uint64.go
+++ b/opt/gotemplate_Uint64.go
@@ -51,7 +51,7 @@ func (v *Uint64) UnmarshalEasyJSON(l *jlexer.Lexer) {
 }
 
 // MarshalJSON implements a standard json marshaler interface.
-func (v *Uint64) MarshalJSON() ([]byte, error) {
+func (v Uint64) MarshalJSON() ([]byte, error) {
 	w := jwriter.Writer{}
 	v.MarshalEasyJSON(&w)
 	return w.Buffer.BuildBytes(), w.Error
@@ -59,7 +59,7 @@ func (v *Uint64) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements a standard json unmarshaler interface.
 func (v *Uint64) UnmarshalJSON(data []byte) error {
-	l := jlexer.Lexer{}
+	l := jlexer.Lexer{Data: data}
 	v.UnmarshalEasyJSON(&l)
 	return l.Error()
 }

--- a/opt/gotemplate_Uint8.go
+++ b/opt/gotemplate_Uint8.go
@@ -51,7 +51,7 @@ func (v *Uint8) UnmarshalEasyJSON(l *jlexer.Lexer) {
 }
 
 // MarshalJSON implements a standard json marshaler interface.
-func (v *Uint8) MarshalJSON() ([]byte, error) {
+func (v Uint8) MarshalJSON() ([]byte, error) {
 	w := jwriter.Writer{}
 	v.MarshalEasyJSON(&w)
 	return w.Buffer.BuildBytes(), w.Error
@@ -59,7 +59,7 @@ func (v *Uint8) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements a standard json unmarshaler interface.
 func (v *Uint8) UnmarshalJSON(data []byte) error {
-	l := jlexer.Lexer{}
+	l := jlexer.Lexer{Data: data}
 	v.UnmarshalEasyJSON(&l)
 	return l.Error()
 }

--- a/opt/optional/opt.go
+++ b/opt/optional/opt.go
@@ -52,7 +52,7 @@ func (v *Optional) UnmarshalEasyJSON(l *jlexer.Lexer) {
 }
 
 // MarshalJSON implements a standard json marshaler interface.
-func (v *Optional) MarshalJSON() ([]byte, error) {
+func (v Optional) MarshalJSON() ([]byte, error) {
 	w := jwriter.Writer{}
 	v.MarshalEasyJSON(&w)
 	return w.Buffer.BuildBytes(), w.Error
@@ -60,7 +60,7 @@ func (v *Optional) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements a standard json unmarshaler interface.
 func (v *Optional) UnmarshalJSON(data []byte) error {
-	l := jlexer.Lexer{}
+	l := jlexer.Lexer{Data: data}
 	v.UnmarshalEasyJSON(&l)
 	return l.Error()
 }

--- a/tests/opt_test.go
+++ b/tests/opt_test.go
@@ -1,0 +1,70 @@
+package tests
+
+import (
+	"math"
+	"reflect"
+	"testing"
+
+	"encoding/json"
+
+	"github.com/mailru/easyjson/opt"
+)
+
+// This struct type must NOT have a generated marshaler
+type OptsVanilla struct {
+	Int  opt.Int
+	Uint opt.Uint
+
+	Int8  opt.Int8
+	Int16 opt.Int16
+	Int32 opt.Int32
+	Int64 opt.Int64
+
+	Uint8  opt.Uint8
+	Uint16 opt.Uint16
+	Uint32 opt.Uint32
+	Uint64 opt.Uint64
+
+	Float32 opt.Float32
+	Float64 opt.Float64
+
+	Bool   opt.Bool
+	String opt.String
+}
+
+var optsVanillaValue = OptsVanilla{
+	Int:  opt.OInt(-123),
+	Uint: opt.OUint(123),
+
+	Int8:  opt.OInt8(math.MaxInt8),
+	Int16: opt.OInt16(math.MaxInt16),
+	Int32: opt.OInt32(math.MaxInt32),
+	Int64: opt.OInt64(math.MaxInt64),
+
+	Uint8:  opt.OUint8(math.MaxUint8),
+	Uint16: opt.OUint16(math.MaxUint16),
+	Uint32: opt.OUint32(math.MaxUint32),
+	Uint64: opt.OUint64(math.MaxUint64),
+
+	Float32: opt.OFloat32(math.MaxFloat32),
+	Float64: opt.OFloat64(math.MaxFloat64),
+
+	Bool:   opt.OBool(true),
+	String: opt.OString("foo"),
+}
+
+func TestOptsVanilla(t *testing.T) {
+	data, err := json.Marshal(optsVanillaValue)
+	if err != nil {
+		t.Errorf("Failed to marshal vanilla opts: %v", err)
+	}
+
+	var ov OptsVanilla
+	if err := json.Unmarshal(data, &ov); err != nil {
+		t.Errorf("Failed to unmarshal vanilla opts: %v", err)
+	}
+
+	if !reflect.DeepEqual(optsVanillaValue, ov) {
+		t.Errorf("Vanilla opts unmarshal returned invalid value %+v, want %+v", ov, optsVanillaValue)
+	}
+}


### PR DESCRIPTION
There were two problems with the optional type wrapper implementation that this PR fixes.

1) `UnmarshalJSON` didn't actually use the provided `data` parameter, always leading to EOF errors. Mentioned in #152.

2) `MarshalJSON` was a pointer method. Thus only `*opt.String` satisfied the `json.Marshaler` interface and `opt.String` didn't, so `json.Marshal` output `{"V":"foo","Defined":true}` instead of `"foo"`.

I also added a test to make sure this stays operational.