### PR TITLE
Fix handling of non-lowercase packages on Windows.

### DIFF
--- a/parser/parser_windows.go
+++ b/parser/parser_windows.go
@@ -9,8 +9,7 @@ import (
 )
 
 func normalizePath(path string) string {
-	// use lower case, as Windows file systems will almost always be case insensitive 
-	return strings.ToLower(strings.Replace(path, "\\", "/", -1))
+	return strings.Replace(path, "\\", "/", -1)
 }
 
 func getPkgPath(fname string, isDir bool) (string, error) {


### PR DESCRIPTION
# The problem
If there is a package with an import path that is not all lowercase, then easyjson will fail.
```
package main: case-insensitive import collision: "github.com/xStrom/skoll/src/api" and "github.com/xstrom/skoll/src/api"
```

# Source of problem
This bug was introduced with PR #130.

The code contains a comment which claims that "*Windows file systems will almost always be case insensitive*". This is a common misconception and not true. [NTFS is case sensetive](https://support.microsoft.com/en-us/help/100625/filenames-are-case-sensitive-on-ntfs-volumes). Although yes most Win32 applications are case insensetive, which is where the confusion comes from. Still, the filesystem itself is case sensetive and it's perfectly legal to write applications that utilize this.

Looking deeper we find issue #129. There it is described that there are problems if your `GOPATH` is defined in a different case than it actually is. One would think that fixing your `GOPATH` is the correct solution, but somehow it was decided that easyjson must be patched instead. It's also puzzling me how in that issue it is claimed that the mismatched case paths *are the same* yet there is a need to convert one to the other?

# The solution
This PR reverts the `normalizePath` function back to what it was before. This way easyjson will once again work with projects that don't use all lowercase imports.

# What about supporting incorrect `GOPATH`?
I think the easiest solution is to define `GOPATH` correctly. If however it is decided that easyjson should also support incorrect `GOPATH` definitions, then I only ask for this support to be added in a way that doesn't break functionality for people who have things defined correctly and also use upper case letters.