### PR TITLE
Add float string functions when requested

### DIFF
--- a/gen/decoder.go
+++ b/gen/decoder.go
@@ -48,8 +48,8 @@ var primitiveStringDecoders = map[reflect.Kind]string{
 	reflect.Uint32:  "in.Uint32Str()",
 	reflect.Uint64:  "in.Uint64Str()",
 	reflect.Uintptr: "in.UintptrStr()",
-	reflect.Float32: "in.Float32()Str",
-	reflect.Float64: "in.Float64()Str",
+	reflect.Float32: "in.Float32Str()",
+	reflect.Float64: "in.Float64Str()",
 }
 
 var customDecoders = map[string]string{

--- a/gen/decoder.go
+++ b/gen/decoder.go
@@ -48,10 +48,12 @@ var primitiveStringDecoders = map[reflect.Kind]string{
 	reflect.Uint32:  "in.Uint32Str()",
 	reflect.Uint64:  "in.Uint64Str()",
 	reflect.Uintptr: "in.UintptrStr()",
+	reflect.Float32: "in.Float32()Str",
+	reflect.Float64: "in.Float64()Str",
 }
 
 var customDecoders = map[string]string{
-	"json.Number":    "in.JsonNumber()",
+	"json.Number": "in.JsonNumber()",
 }
 
 // genTypeDecoder generates decoding code for the type t, but uses unmarshaler interface if implemented by t.
@@ -88,7 +90,7 @@ func (g *Generator) genTypeDecoder(t reflect.Type, out string, tags fieldTags, i
 func (g *Generator) genTypeDecoderNoCheck(t reflect.Type, out string, tags fieldTags, indent int) error {
 	ws := strings.Repeat("  ", indent)
 	// Check whether type is primitive, needs to be done after interface check.
-	if dec := customDecoders[t.String()]; dec != ""  {
+	if dec := customDecoders[t.String()]; dec != "" {
 		fmt.Fprintln(g.out, ws+out+" = "+dec)
 		return nil
 	} else if dec := primitiveStringDecoders[t.Kind()]; dec != "" && tags.asString {

--- a/gen/encoder.go
+++ b/gen/encoder.go
@@ -45,6 +45,8 @@ var primitiveStringEncoders = map[reflect.Kind]string{
 	reflect.Uint32:  "out.Uint32Str(uint32(%v))",
 	reflect.Uint64:  "out.Uint64Str(uint64(%v))",
 	reflect.Uintptr: "out.UintptrStr(uintptr(%v))",
+	reflect.Float32: "out.Float32Str(float32(%v))",
+	reflect.Float64: "out.Float64Str(float64(%v))",
 }
 
 // fieldTags contains parsed version of json struct field tags.

--- a/jlexer/lexer.go
+++ b/jlexer/lexer.go
@@ -1043,7 +1043,7 @@ func (r *Lexer) Float64Str() float64 {
 			Data:   string(b),
 		})
 	}
-	return float64(n)
+	return n
 }
 
 func (r *Lexer) Error() error {

--- a/jlexer/lexer.go
+++ b/jlexer/lexer.go
@@ -997,6 +997,22 @@ func (r *Lexer) Float32() float32 {
 	return float32(n)
 }
 
+func (r *Lexer) Float32Str() float32 {
+	s, b := r.unsafeString()
+	if !r.Ok() {
+		return 0
+	}
+	n, err := strconv.ParseFloat(s, 32)
+	if err != nil {
+		r.addNonfatalError(&LexerError{
+			Offset: r.start,
+			Reason: err.Error(),
+			Data:   string(b),
+		})
+	}
+	return float32(n)
+}
+
 func (r *Lexer) Float64() float64 {
 	s := r.number()
 	if !r.Ok() {
@@ -1012,6 +1028,22 @@ func (r *Lexer) Float64() float64 {
 		})
 	}
 	return n
+}
+
+func (r *Lexer) Float64Str() float64 {
+	s, b := r.unsafeString()
+	if !r.Ok() {
+		return 0
+	}
+	n, err := strconv.ParseFloat(s, 64)
+	if err != nil {
+		r.addNonfatalError(&LexerError{
+			Offset: r.start,
+			Reason: err.Error(),
+			Data:   string(b),
+		})
+	}
+	return float64(n)
 }
 
 func (r *Lexer) Error() error {

--- a/jwriter/writer.go
+++ b/jwriter/writer.go
@@ -240,9 +240,23 @@ func (w *Writer) Float32(n float32) {
 	w.Buffer.Buf = strconv.AppendFloat(w.Buffer.Buf, float64(n), 'g', -1, 32)
 }
 
+func (w *Writer) Float32Str(n float32) {
+	w.Buffer.EnsureSpace(20)
+	w.Buffer.Buf = append(w.Buffer.Buf, '"')
+	w.Buffer.Buf = strconv.AppendFloat(w.Buffer.Buf, float64(n), 'g', -1, 32)
+	w.Buffer.Buf = append(w.Buffer.Buf, '"')
+}
+
 func (w *Writer) Float64(n float64) {
 	w.Buffer.EnsureSpace(20)
 	w.Buffer.Buf = strconv.AppendFloat(w.Buffer.Buf, n, 'g', -1, 64)
+}
+
+func (w *Writer) Float64Str(n float64) {
+	w.Buffer.EnsureSpace(20)
+	w.Buffer.Buf = append(w.Buffer.Buf, '"')
+	w.Buffer.Buf = strconv.AppendFloat(w.Buffer.Buf, float64(n), 'g', -1, 64)
+	w.Buffer.Buf = append(w.Buffer.Buf, '"')
 }
 
 func (w *Writer) Bool(v bool) {
@@ -340,11 +354,10 @@ func (w *Writer) base64(in []byte) {
 		return
 	}
 
-	w.Buffer.EnsureSpace(((len(in) - 1) / 3 + 1) * 4)
+	w.Buffer.EnsureSpace(((len(in)-1)/3 + 1) * 4)
 
 	si := 0
 	n := (len(in) / 3) * 3
-
 
 	for si < n {
 		// Convert 3x 8bit source bytes into 4 bytes

--- a/tests/data.go
+++ b/tests/data.go
@@ -38,8 +38,11 @@ type PrimitiveTypes struct {
 	Uint32String uint32 `json:",string"`
 	Uint64String uint64 `json:",string"`
 
-	Float32 float32 `json:",string"`
-	Float64 float64 `json:",string"`
+	Float32 float32
+	Float64 float64
+
+	Float32String float32 `json:",string"`
+	Float64String float64 `json:",string"`
 
 	Ptr    *string
 	PtrNil *string
@@ -77,6 +80,9 @@ var primitiveTypesValue = PrimitiveTypes{
 	Float32: 1.5,
 	Float64: math.MaxFloat64,
 
+	Float32String: 1.5,
+	Float64String: math.MaxFloat64,
+
 	Ptr: &str,
 }
 
@@ -109,6 +115,9 @@ var primitiveTypesString = "{" +
 
 	`"Float32":` + fmt.Sprint(1.5) + `,` +
 	`"Float64":` + fmt.Sprint(math.MaxFloat64) + `,` +
+
+	`"Float32String":"` + fmt.Sprint(1.5) + `",` +
+	`"Float64String":"` + fmt.Sprint(math.MaxFloat64) + `",` +
 
 	`"Ptr":"bla",` +
 	`"PtrNil":null` +

--- a/tests/data.go
+++ b/tests/data.go
@@ -38,8 +38,8 @@ type PrimitiveTypes struct {
 	Uint32String uint32 `json:",string"`
 	Uint64String uint64 `json:",string"`
 
-	Float32 float32
-	Float64 float64
+	Float32 float32 `json:", string"`
+	Float64 float64 `json:", string"`
 
 	Ptr    *string
 	PtrNil *string

--- a/tests/data.go
+++ b/tests/data.go
@@ -38,8 +38,8 @@ type PrimitiveTypes struct {
 	Uint32String uint32 `json:",string"`
 	Uint64String uint64 `json:",string"`
 
-	Float32 float32 `json:", string"`
-	Float64 float64 `json:", string"`
+	Float32 float32 `json:",string"`
+	Float64 float64 `json:",string"`
 
 	Ptr    *string
 	PtrNil *string


### PR DESCRIPTION
When a float would have a `json: ",string"` – the parser would fail if it got some json that had a float "string" type

Signed-off-by: Levi Gross <levi@levigross.com>