### PR TITLE
fix invalid indirect of a pointer on a array

### DIFF
--- a/gen/decoder.go
+++ b/gen/decoder.go
@@ -51,7 +51,7 @@ var primitiveStringDecoders = map[reflect.Kind]string{
 }
 
 var customDecoders = map[string]string{
-	"json.Number":    "in.JsonNumber()",
+	"json.Number": "in.JsonNumber()",
 }
 
 // genTypeDecoder generates decoding code for the type t, but uses unmarshaler interface if implemented by t.
@@ -88,7 +88,7 @@ func (g *Generator) genTypeDecoder(t reflect.Type, out string, tags fieldTags, i
 func (g *Generator) genTypeDecoderNoCheck(t reflect.Type, out string, tags fieldTags, indent int) error {
 	ws := strings.Repeat("  ", indent)
 	// Check whether type is primitive, needs to be done after interface check.
-	if dec := customDecoders[t.String()]; dec != ""  {
+	if dec := customDecoders[t.String()]; dec != "" {
 		fmt.Fprintln(g.out, ws+out+" = "+dec)
 		return nil
 	} else if dec := primitiveStringDecoders[t.Kind()]; dec != "" && tags.asString {
@@ -170,7 +170,7 @@ func (g *Generator) genTypeDecoderNoCheck(t reflect.Type, out string, tags field
 			fmt.Fprintln(g.out, ws+"  for !in.IsDelim(']') {")
 			fmt.Fprintln(g.out, ws+"    if "+iterVar+" < "+fmt.Sprint(length)+" {")
 
-			if err := g.genTypeDecoder(elem, out+"["+iterVar+"]", tags, indent+3); err != nil {
+			if err := g.genTypeDecoder(elem, "("+out+")["+iterVar+"]", tags, indent+3); err != nil {
 				return err
 			}
 

--- a/gen/encoder.go
+++ b/gen/encoder.go
@@ -165,7 +165,7 @@ func (g *Generator) genTypeEncoderNoCheck(t reflect.Type, in string, tags fieldT
 			fmt.Fprintln(g.out, ws+"    out.RawByte(',')")
 			fmt.Fprintln(g.out, ws+"  }")
 
-			if err := g.genTypeEncoder(elem, in+"["+iVar+"]", tags, indent+1, false); err != nil {
+			if err := g.genTypeEncoder(elem, "("+in+")["+iVar+"]", tags, indent+1, false); err != nil {
 				return err
 			}
 

--- a/tests/basic_test.go
+++ b/tests/basic_test.go
@@ -47,6 +47,7 @@ var testCases = []struct {
 	{&mapUint64StringValue, mapUint64StringValueString},
 	{&mapUintptrStringValue, mapUintptrStringValueString},
 	{&intKeyedMapStructValue, intKeyedMapStructValueString},
+	{&intArrayStructValue, intArrayStructValueString},
 }
 
 func TestMarshal(t *testing.T) {

--- a/tests/data.go
+++ b/tests/data.go
@@ -757,3 +757,21 @@ var intKeyedMapStructValueString = `{` +
 	`"foo":{"42":"life"},` +
 	`"bar":{"32":{"354634382":"life"}}` +
 	`}`
+
+type IntArray [2]int
+
+//easyjson:json
+type IntArrayStruct struct {
+	Pointer *IntArray `json:"pointer"`
+	Value   IntArray  `json:"value"`
+}
+
+var intArrayStructValue = IntArrayStruct{
+	Pointer: &IntArray{1, 2},
+	Value:   IntArray{1, 2},
+}
+
+var intArrayStructValueString = `{` +
+	`"pointer":[1,2],` +
+	`"value":[1,2]` +
+	`}`


### PR DESCRIPTION
The generator works wrong if we have a pointer on an array.
Sample code:
```go
type IntArray [2]int

//easyjson:json
type IntArrayStruct struct {
	Pointer *IntArray `json:"pointer"`
	Value   IntArray  `json:"value"`
}
```
The error:
```
.root/src/github.com/mailru/easyjson/tests/data_easyjson.go:3838: invalid indirect of out.Pointer[v71] (type int)
.root/src/github.com/mailru/easyjson/tests/data_easyjson.go:3895: invalid indirect of in.Pointer[v73] (type int)
```
The generated code is before the fix:
```go
for !in.IsDelim(']') {
	if v71 < 2 {
		*out.Pointer[v71] = int(in.Int()) // <------------
		v71++
	} else {
		in.SkipRecursive()
	}
	in.WantComma()
}
```	
After the fix:
```go
for !in.IsDelim(']') {
	if v71 < 2 {
		(*out.Pointer)[v71] = int(in.Int()) // <------------
		v71++
	} else {
		in.SkipRecursive()
	}
	in.WantComma()
}
```	