### PR TITLE
Make json.Number handling similar to encoding/json

### DIFF
--- a/jlexer/lexer.go
+++ b/jlexer/lexer.go
@@ -1056,7 +1056,7 @@ func (r *Lexer) JsonNumber() json.Number {
 	}
 	if !r.Ok() {
 		r.errInvalidToken("json.Number")
-		return json.Number("0")
+		return json.Number("")
 	}
 
 	switch r.token.kind {
@@ -1064,9 +1064,11 @@ func (r *Lexer) JsonNumber() json.Number {
 		return json.Number(r.String())
 	case tokenNumber:
 		return json.Number(r.Raw())
+	case tokenNull:
+		return json.Number("")
 	default:
 		r.errSyntax()
-		return json.Number("0")
+		return json.Number("")
 	}
 }
 

--- a/jlexer/lexer_test.go
+++ b/jlexer/lexer_test.go
@@ -25,9 +25,9 @@ func TestString(t *testing.T) {
 
 		{toParse: `"test"junk`, want: "test"},
 
-		{toParse: `5`, wantError: true},        // not a string
-		{toParse: `"\x"`, wantError: true},     // invalid escape
-		{toParse: `"\ud800"`, want: "�"},      // invalid utf-8 char; return replacement char
+		{toParse: `5`, wantError: true},    // not a string
+		{toParse: `"\x"`, wantError: true}, // invalid escape
+		{toParse: `"\ud800"`, want: "�"},   // invalid utf-8 char; return replacement char
 	} {
 		l := Lexer{Data: []byte(test.toParse)}
 
@@ -269,16 +269,19 @@ func TestJsonNumber(t *testing.T) {
 		{toParse: `"0.12"`, want: json.Number("0.12"), wantValue: 0.12},
 		{toParse: `"25E-4"`, want: json.Number("25E-4"), wantValue: 25E-4},
 
-		{toParse: `"a""`, wantValueError: true},
+		{toParse: `"foo"`, want: json.Number("foo"), wantValueError: true},
+		{toParse: `null`, want: json.Number(""), wantValueError: true},
 
-		{toParse: `[1]`, wantLexerError: true},
-		{toParse: `{}`, wantLexerError: true},
-		{toParse: `a`, wantLexerError: true},
+		{toParse: `"a""`, want: json.Number("a"), wantValueError: true},
+
+		{toParse: `[1]`, want: json.Number(""), wantLexerError: true, wantValueError: true},
+		{toParse: `{}`, want: json.Number(""), wantLexerError: true, wantValueError: true},
+		{toParse: `a`, want: json.Number(""), wantLexerError: true, wantValueError: true},
 	} {
 		l := Lexer{Data: []byte(test.toParse)}
 
 		got := l.JsonNumber()
-		if got != test.want && !test.wantLexerError && !test.wantValueError {
+		if got != test.want {
 			t.Errorf("[%d, %q] JsonNumber() = %v; want %v", i, test.toParse, got, test.want)
 		}
 
@@ -303,7 +306,7 @@ func TestJsonNumber(t *testing.T) {
 		}
 
 		if valueErr != nil && !test.wantValueError {
-			t.Errorf("[%d, %q] JsonNumber() value error: %v", i, test.toParse, err)
+			t.Errorf("[%d, %q] JsonNumber() value error: %v", i, test.toParse, valueErr)
 		} else if valueErr == nil && test.wantValueError {
 			t.Errorf("[%d, %q] JsonNumber() ok; want value error", i, test.toParse)
 		}


### PR DESCRIPTION
This change modified the `json.Number` unmarshaling to handle `null`
values without error, similar to `encoding/json`. These values are
become `json.Number("")`.

This also modifies the json.Number value returned on error to be
`json.Number("")` as that is the zero value.

See https://play.golang.org/p/knZLugaqnni