### PR TITLE
Embedded unnamed types fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,8 @@ generate: root build
 		.root/src/$(PKG)/tests/data.go \
 		.root/src/$(PKG)/tests/omitempty.go \
 		.root/src/$(PKG)/tests/nothing.go \
-		.root/src/$(PKG)/tests/named_type.go
+		.root/src/$(PKG)/tests/named_type.go \
+		.root/src/$(PKG)/tests/embedded_type.go
 
 	.root/bin/easyjson -all .root/src/$(PKG)/tests/data.go 
 	.root/bin/easyjson -all .root/src/$(PKG)/tests/nothing.go
@@ -33,6 +34,7 @@ generate: root build
 	.root/bin/easyjson -build_tags=use_easyjson .root/src/$(PKG)/benchmark/data.go
 	.root/bin/easyjson .root/src/$(PKG)/tests/nested_easy.go
 	.root/bin/easyjson .root/src/$(PKG)/tests/named_type.go
+	.root/bin/easyjson .root/src/$(PKG)/tests/embedded_type.go
 
 test: generate root
 	go test \

--- a/gen/generator.go
+++ b/gen/generator.go
@@ -284,7 +284,11 @@ func (g *Generator) getType(t reflect.Type) string {
 			lines := make([]string, 0, nf)
 			for i := 0; i < nf; i++ {
 				f := t.Field(i)
-				line := f.Name + " " + g.getType(f.Type)
+				var line string
+				if !f.Anonymous {
+					line = f.Name + " "
+				} // else the field is anonymous (an embedded type)
+				line += g.getType(f.Type)
 				t := f.Tag
 				if t != "" {
 					line += " " + escapeTag(t)

--- a/tests/basic_test.go
+++ b/tests/basic_test.go
@@ -38,6 +38,7 @@ var testCases = []struct {
 	{&IntsValue, IntsString},
 	{&mapStringStringValue, mapStringStringString},
 	{&namedTypeValue, namedTypeValueString},
+	{&embeddedTypeValue, embeddedTypeValueString},
 	{&mapMyIntStringValue, mapMyIntStringValueString},
 	{&mapIntStringValue, mapIntStringValueString},
 	{&mapInt32StringValue, mapInt32StringValueString},

--- a/tests/embedded_type.go
+++ b/tests/embedded_type.go
@@ -1,0 +1,24 @@
+package tests
+
+//easyjson:json
+type EmbeddedType struct {
+	EmbeddedInnerType
+	Inner struct {
+		EmbeddedInnerType
+	}
+	Field2 int
+}
+
+type EmbeddedInnerType struct {
+	Field1 int
+}
+
+var embeddedTypeValue EmbeddedType
+
+func init() {
+	embeddedTypeValue.Field1 = 1
+	embeddedTypeValue.Field2 = 2
+	embeddedTypeValue.Inner.Field1 = 3
+}
+
+var embeddedTypeValueString = `{"Inner":{"Field1":3},"Field2":2,"Field1":1}`


### PR DESCRIPTION
I found a bug in some code I sent last year which handles unnamed types. The bug is that embedded types inside unnamed types weren't generating code which would compile.

This fixes it, as well as adds a unit test for this sort of situation.