### PR TITLE
reduce the unit test map to 1 element so the encoding is consistent

### DIFF
--- a/tests/custom_map_key_type.go
+++ b/tests/custom_map_key_type.go
@@ -22,9 +22,8 @@ var customMapKeyTypeValue CustomMapKeyType
 
 func init() {
 	customMapKeyTypeValue.Map = map[customKeyType]int{
-		customKeyType{0x01, 0x01}: 1,
-		customKeyType{0x02, 0x02}: 2,
+		customKeyType{0x01, 0x02}: 3,
 	}
 }
 
-var customMapKeyTypeValueString = `{"Map":{"0101":1,"0202":2}}`
+var customMapKeyTypeValueString = `{"Map":{"0102":3}}`


### PR DESCRIPTION
The unit test in the new code sometimes fails because of the map iteration order.

This works around the by having the test map have only one element, thus making the result predictable.