### PR TITLE
Correctly consume the null value for json.Number

### DIFF
--- a/jlexer/lexer.go
+++ b/jlexer/lexer.go
@@ -1097,6 +1097,7 @@ func (r *Lexer) JsonNumber() json.Number {
 	case tokenNumber:
 		return json.Number(r.Raw())
 	case tokenNull:
+		r.Null()
 		return json.Number("")
 	default:
 		r.errSyntax()


### PR DESCRIPTION
I noticed this while integrating master with #163 into my project. The issue is that the position did not get updated correctly causing it to reprocess the token. I looked for examples that test the position in `lexer_test.go` but did not see any.