### PR TITLE
#162 using default GOPATH for win and trim last newline character

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -93,5 +93,5 @@ func (p *Parser) Parse(fname string, isDir bool) error {
 
 func getDefaultGoPath() (string, error) {
 	output, err := exec.Command("go", "env", "GOPATH").Output()
-	return string(output), err
+	return strings.TrimSpace(string(output)), err
 }

--- a/parser/parser_windows.go
+++ b/parser/parser_windows.go
@@ -9,7 +9,7 @@ import (
 )
 
 func normalizePath(path string) string {
-	// use lower case, as Windows file systems will almost always be case insensitive 
+	// use lower case, as Windows file systems will almost always be case insensitive
 	return strings.ToLower(strings.Replace(path, "\\", "/", -1))
 }
 
@@ -34,7 +34,7 @@ func getPkgPath(fname string, isDir bool) (string, error) {
 		}
 	}
 
-	for _, p := range strings.Split(os.Getenv("GOPATH"), ";") {
+	for _, p := range strings.Split(gopath, ";") {
 		prefix := path.Join(normalizePath(p), "src") + "/"
 		if rel := strings.TrimPrefix(fname, prefix); rel != fname {
 			if !isDir {


### PR DESCRIPTION
fix #162 for win and handle last newline character from `go env GOPATH`, sorry that I'm not included this in previous pull request