### PR TITLE
Allow pre-process before marshal and post-process after unmarshal.

### DIFF
--- a/easyjson/main.go
+++ b/easyjson/main.go
@@ -61,19 +61,19 @@ func generate(fname string) (err error) {
 	}
 
 	g := bootstrap.Generator{
-		BuildTags:             trimmedBuildTags,
-		PkgPath:               p.PkgPath,
-		PkgName:               p.PkgName,
-		Types:                 p.StructNames,
-		SnakeCase:             *snakeCase,
-		LowerCamelCase:        *lowerCamelCase,
-		NoStdMarshalers:       *noStdMarshalers,
-		DisallowUnknownFields: *disallowUnknownFields,
-		OmitEmpty:             *omitEmpty,
-		LeaveTemps:            *leaveTemps,
-		OutName:               outName,
-		StubsOnly:             *stubs,
-		NoFormat:              *noformat,
+		BuildTags: trimmedBuildTags,
+		PkgPath:   p.PkgPath,
+		PkgName:   p.PkgName,
+		Types:     p.StructNames,
+		SnakeCase: *snakeCase,
+		// LowerCamelCase:        *lowerCamelCase,
+		NoStdMarshalers: *noStdMarshalers,
+		// DisallowUnknownFields: *disallowUnknownFields,
+		OmitEmpty:  *omitEmpty,
+		LeaveTemps: *leaveTemps,
+		OutName:    outName,
+		StubsOnly:  *stubs,
+		NoFormat:   *noformat,
 	}
 
 	if err := g.Run(); err != nil {

--- a/helpers.go
+++ b/helpers.go
@@ -16,9 +16,19 @@ type Marshaler interface {
 	MarshalEasyJSON(w *jwriter.Writer)
 }
 
+type AdvancedMarshaler interface {
+	Marshaler
+	BeforeMarshalEasyJSON()
+}
+
 // Marshaler is an easyjson-compatible unmarshaler interface.
 type Unmarshaler interface {
 	UnmarshalEasyJSON(w *jlexer.Lexer)
+}
+
+type AdvancedUnmarshaler interface {
+	UnmarshalEasyJSON(w *jlexer.Lexer)
+	AfterUnmarshalEasyJSON()
 }
 
 // Optional defines an undefined-test method for a type to integrate with 'omitempty' logic.
@@ -30,14 +40,22 @@ type Optional interface {
 // from a chain of smaller chunks.
 func Marshal(v Marshaler) ([]byte, error) {
 	w := jwriter.Writer{}
-	v.MarshalEasyJSON(&w)
+	if c, ok := v.(AdvancedMarshaler); ok {
+		c.MarshalEasyJSON(&w)
+	} else {
+		v.MarshalEasyJSON(&w)
+	}
 	return w.BuildBytes()
 }
 
 // MarshalToWriter marshals the data to an io.Writer.
 func MarshalToWriter(v Marshaler, w io.Writer) (written int, err error) {
 	jw := jwriter.Writer{}
-	v.MarshalEasyJSON(&jw)
+	if c, ok := v.(AdvancedMarshaler); ok {
+		c.MarshalEasyJSON(&jw)
+	} else {
+		v.MarshalEasyJSON(&jw)
+	}
 	return jw.DumpTo(w)
 }
 
@@ -47,7 +65,11 @@ func MarshalToWriter(v Marshaler, w io.Writer) (written int, err error) {
 // invoked (in this case a 500 reply is possible).
 func MarshalToHTTPResponseWriter(v Marshaler, w http.ResponseWriter) (started bool, written int, err error) {
 	jw := jwriter.Writer{}
-	v.MarshalEasyJSON(&jw)
+	if c, ok := v.(AdvancedMarshaler); ok {
+		c.MarshalEasyJSON(&jw)
+	} else {
+		v.MarshalEasyJSON(&jw)
+	}
 	if jw.Error != nil {
 		return false, 0, jw.Error
 	}
@@ -62,7 +84,11 @@ func MarshalToHTTPResponseWriter(v Marshaler, w http.ResponseWriter) (started bo
 // Unmarshal decodes the JSON in data into the object.
 func Unmarshal(data []byte, v Unmarshaler) error {
 	l := jlexer.Lexer{Data: data}
-	v.UnmarshalEasyJSON(&l)
+	if c, ok := v.(AdvancedUnmarshaler); ok {
+		c.UnmarshalEasyJSON(&l)
+	} else {
+		v.UnmarshalEasyJSON(&l)
+	}
 	return l.Error()
 }
 
@@ -73,6 +99,10 @@ func UnmarshalFromReader(r io.Reader, v Unmarshaler) error {
 		return err
 	}
 	l := jlexer.Lexer{Data: data}
-	v.UnmarshalEasyJSON(&l)
+	if c, ok := v.(AdvancedUnmarshaler); ok {
+		c.UnmarshalEasyJSON(&l)
+	} else {
+		v.UnmarshalEasyJSON(&l)
+	}
 	return l.Error()
 }

--- a/helpers.go
+++ b/helpers.go
@@ -41,6 +41,7 @@ type Optional interface {
 func Marshal(v Marshaler) ([]byte, error) {
 	w := jwriter.Writer{}
 	if c, ok := v.(AdvancedMarshaler); ok {
+		c.BeforeMarshalEasyJSON()
 		c.MarshalEasyJSON(&w)
 	} else {
 		v.MarshalEasyJSON(&w)
@@ -52,6 +53,7 @@ func Marshal(v Marshaler) ([]byte, error) {
 func MarshalToWriter(v Marshaler, w io.Writer) (written int, err error) {
 	jw := jwriter.Writer{}
 	if c, ok := v.(AdvancedMarshaler); ok {
+		c.BeforeMarshalEasyJSON()
 		c.MarshalEasyJSON(&jw)
 	} else {
 		v.MarshalEasyJSON(&jw)
@@ -66,6 +68,7 @@ func MarshalToWriter(v Marshaler, w io.Writer) (written int, err error) {
 func MarshalToHTTPResponseWriter(v Marshaler, w http.ResponseWriter) (started bool, written int, err error) {
 	jw := jwriter.Writer{}
 	if c, ok := v.(AdvancedMarshaler); ok {
+		c.BeforeMarshalEasyJSON()
 		c.MarshalEasyJSON(&jw)
 	} else {
 		v.MarshalEasyJSON(&jw)
@@ -86,6 +89,7 @@ func Unmarshal(data []byte, v Unmarshaler) error {
 	l := jlexer.Lexer{Data: data}
 	if c, ok := v.(AdvancedUnmarshaler); ok {
 		c.UnmarshalEasyJSON(&l)
+		c.AfterUnmarshalEasyJSON()
 	} else {
 		v.UnmarshalEasyJSON(&l)
 	}
@@ -101,6 +105,7 @@ func UnmarshalFromReader(r io.Reader, v Unmarshaler) error {
 	l := jlexer.Lexer{Data: data}
 	if c, ok := v.(AdvancedUnmarshaler); ok {
 		c.UnmarshalEasyJSON(&l)
+		c.AfterUnmarshalEasyJSON()
 	} else {
 		v.UnmarshalEasyJSON(&l)
 	}


### PR DESCRIPTION
Use case:

Consider this struct:

```
type Project struct {
    Company *Company `json:"-"`
    CompanyID string `json:"companyID"`
}
```

The reason why `CompanyID` is created is:

With the use of ORM, it's a typical setup.
Usually we can get the `Company` directly from an DB read, however, when sending the data in JSON format over to the client, they expect the companyID without a nested JSON. 

They don't want this:
```
{
  "project": {
    "company": {
      "id": "id"
    }
  }
}
```

But this:
```
{
  "project": {
    "companyID": "id"
  }
}
```

In order to achieve this, at every place where I want to marshal `Project` into JSON, I have to do the following manually:

```
project.CompanyID = project.Company.ID
```

If we can have the pre-process ability, I can implement the `BeforeMarshalEasyJSON` function for this struct, as:

```
func (o *Project) BeforeMarshalEasyJSON() {
    o.CompanyID = o.Company.ID
}
```

And then when it's marshalled to JSON, this `BeforeMarshalEasyJSON` method is automatically called be the struct is marshalled.

This will really help a lot.