### PR TITLE
Use go/build to get default GOPATH

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -1,11 +1,9 @@
 package parser
 
 import (
-	"bytes"
 	"go/ast"
 	"go/parser"
 	"go/token"
-	"os/exec"
 	"strings"
 )
 
@@ -90,9 +88,4 @@ func (p *Parser) Parse(fname string, isDir bool) error {
 		ast.Walk(&visitor{Parser: p}, f)
 	}
 	return nil
-}
-
-func getDefaultGoPath() (string, error) {
-	output, err := exec.Command("go", "env", "GOPATH").Output()
-	return string(bytes.TrimSpace(output)), err
 }

--- a/parser/pkgpath.go
+++ b/parser/pkgpath.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"go/build"
 )
 
 func getPkgPath(fname string, isDir bool) (string, error) {
@@ -137,11 +138,7 @@ func getModulePath(goModPath string) string {
 func getPkgPathFromGOPATH(fname string, isDir bool) (string, error) {
 	gopath := os.Getenv("GOPATH")
 	if gopath == "" {
-		var err error
-		gopath, err = getDefaultGoPath()
-		if err != nil {
-			return "", fmt.Errorf("cannot determine GOPATH: %s", err)
-		}
+		gopath = build.Default.GOPATH
 	}
 
 	for _, p := range strings.Split(gopath, string(filepath.ListSeparator)) {


### PR DESCRIPTION
Old approach was failing for me on macOS, so I always had to run `export GOPATH=$(go env GOPATH)` before using easyjson. I did not bother debugging it -- I just rewrote it.
This approach seems to be more solid, and should work on go1.8+.