### PR TITLE
changed the unmarshalling behaviour for unmarshalling {"key": []} int…

### DIFF
--- a/jlexer/lexer.go
+++ b/jlexer/lexer.go
@@ -1151,7 +1151,7 @@ func (r *Lexer) Interface() interface{} {
 	} else if r.token.delimValue == '[' {
 		r.consume()
 
-		var ret []interface{}
+		ret := []interface{}{}
 		for !r.IsDelim(']') {
 			ret = append(ret, r.Interface())
 			r.WantComma()

--- a/jlexer/lexer_test.go
+++ b/jlexer/lexer_test.go
@@ -194,7 +194,7 @@ func TestInterface(t *testing.T) {
 		{toParse: "5", want: float64(5)},
 
 		{toParse: `{}`, want: map[string]interface{}{}},
-		{toParse: `[]`, want: []interface{}(nil)},
+		{toParse: `[]`, want: []interface{}{}},
 
 		{toParse: `{"a": "b"}`, want: map[string]interface{}{"a": "b"}},
 		{toParse: `[5]`, want: []interface{}{float64(5)}},


### PR DESCRIPTION
…o map[string]interface{}. The value for "key" in the map will be an empty slice instead of a nil slice.

For issue #188 