### PR TITLE
Retry if it fails due to change of dependent struct

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,4 @@ install:
   - go get github.com/ugorji/go/codec
   - go get github.com/pquerna/ffjson/fflib/v1
   - go get github.com/json-iterator/go
-  - go get github.com/golang/lint/golint
+  - go get golang.org/x/lint/golint


### PR DESCRIPTION
When it changes dependent struct and run easyjson, it gets error like following and aborts immediately. 

```
$ cat b/struct.go
package b

type Foo struct {
        A int  `json:"a,omitempty"`
        B *Bar `json:"b"`
}

$ cat b/struct2.go
package b

type Bar struct {
        C []int          `json:"c"`
        D map[string]int `json:"d"`
}

$ easyjson -all b/struct.go b/struct2.go
$ vi b/struct2.go
package b

type Bar struct {
        C []string       `json:"c"` // change type
        D map[string]int `json:"d"`
}

easyjson -all b/struct.go b/struct2.go
./struct2_easyjson.go:47:13: cannot use make([]int, 0, 8) (type []int) as type []string in assignment
./struct2_easyjson.go:49:13: cannot use []int literal (type []int) as type []string in assignment
./struct2_easyjson.go:57:20: cannot use v1 (type int) as type string in append
./struct2_easyjson.go:112:16: cannot convert v4 (type string) to type int
Bootstrap failed: exit status 2
```

If it runs `easyjson -all b/struct2.go b/struct.go` instead of `easyjson -all b/struct.go b/struct2.go` (change the files order), it succeeds. However if the struct relations will get more complex, it will be hard to solve. 
This PR solves this issue by retrying if the number of failures has decreased.
