### PR TITLE
Stdlib json handles embedded structs with json tags differently.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,4 @@ install:
   - go get github.com/ugorji/go/codec
   - go get github.com/pquerna/ffjson/fflib/v1
   - go get github.com/json-iterator/go
-  - go get github.com/golang/lint/golint
+  - go get golang.org/x/lint/golint

--- a/gen/decoder.go
+++ b/gen/decoder.go
@@ -343,7 +343,8 @@ func getStructFields(t reflect.Type) ([]reflect.StructField, error) {
 	var efields []reflect.StructField
 	for i := 0; i < t.NumField(); i++ {
 		f := t.Field(i)
-		if !f.Anonymous {
+		tags := parseFieldTags(f)
+		if !f.Anonymous || tags.name != "" {
 			continue
 		}
 
@@ -362,7 +363,8 @@ func getStructFields(t reflect.Type) ([]reflect.StructField, error) {
 	var fields []reflect.StructField
 	for i := 0; i < t.NumField(); i++ {
 		f := t.Field(i)
-		if f.Anonymous {
+		tags := parseFieldTags(f)
+		if f.Anonymous && tags.name == "" {
 			continue
 		}
 

--- a/tests/embedded_type.go
+++ b/tests/embedded_type.go
@@ -6,11 +6,16 @@ type EmbeddedType struct {
 	Inner struct {
 		EmbeddedInnerType
 	}
-	Field2 int
+	Field2             int
+	EmbeddedInnerType2 `json:"named"`
 }
 
 type EmbeddedInnerType struct {
 	Field1 int
+}
+
+type EmbeddedInnerType2 struct {
+	Field3 int
 }
 
 var embeddedTypeValue EmbeddedType
@@ -19,6 +24,7 @@ func init() {
 	embeddedTypeValue.Field1 = 1
 	embeddedTypeValue.Field2 = 2
 	embeddedTypeValue.Inner.Field1 = 3
+	embeddedTypeValue.Field3 = 4
 }
 
-var embeddedTypeValueString = `{"Inner":{"Field1":3},"Field2":2,"Field1":1}`
+var embeddedTypeValueString = `{"Inner":{"Field1":3},"Field2":2,"named":{"Field3":4},"Field1":1}`


### PR DESCRIPTION
See 	https://play.golang.org/p/KXZbjG0JBle for an example

```go
package main

import (
	"fmt"
	"encoding/json"
)

func main() {
	type Embed1 struct {
		Field1 int
	}
	type Embed2 struct {
		Field2 int
	}

	type test struct {
		Embed1
		Embed2 `json:"named"`
	}
	
	var v test
	
	data, _ := json.MarshalIndent(v, "", "\t")
	fmt.Println(string(data))
}
```

```json
{
	"Field1": 0,
	"named": {
		"Field2": 0
	}
}
```