### PR TITLE
*_test package name in _test.go files

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -39,6 +39,11 @@ func (v *visitor) Visit(n ast.Node) (w ast.Visitor) {
 	case *ast.Package:
 		return v
 	case *ast.File:
+		if n.Name.String() == v.PkgName + "_test" {
+			//don't overwrite if new package name is
+			//_test derivative of earlier name
+			return v
+		}
 		v.PkgName = n.Name.String()
 		return v
 


### PR DESCRIPTION
handled the case where generator was failing because of the presence of
_test package named test files in the package folder

Currently skipping identical package names ending with _test in parser.