### PR TITLE
improved gen getStructFields: for anonymous field that is not a struct.

### DIFF
--- a/gen/decoder.go
+++ b/gen/decoder.go
@@ -341,6 +341,7 @@ func getStructFields(t reflect.Type) ([]reflect.StructField, error) {
 	}
 
 	var efields []reflect.StructField
+	var fields []reflect.StructField
 	for i := 0; i < t.NumField(); i++ {
 		f := t.Field(i)
 		if !f.Anonymous {
@@ -352,14 +353,20 @@ func getStructFields(t reflect.Type) ([]reflect.StructField, error) {
 			t1 = t1.Elem()
 		}
 
-		fs, err := getStructFields(t1)
-		if err != nil {
-			return nil, fmt.Errorf("error processing embedded field: %v", err)
+		if t1.Kind() == reflect.Struct {
+			fs, err := getStructFields(t1)
+			if err != nil {
+				return nil, fmt.Errorf("error processing embedded field: %v", err)
+			}
+			efields = mergeStructFields(efields, fs)
+		} else {
+			if strings.Contains(f.Name, ".") || unicode.IsUpper([]rune(f.Name)[0]) {
+				fields = append(fields, f)
+			}
 		}
-		efields = mergeStructFields(efields, fs)
 	}
 
-	var fields []reflect.StructField
+
 	for i := 0; i < t.NumField(); i++ {
 		f := t.Field(i)
 		if f.Anonymous {

--- a/gen/decoder.go
+++ b/gen/decoder.go
@@ -353,13 +353,14 @@ func getStructFields(t reflect.Type) ([]reflect.StructField, error) {
 			t1 = t1.Elem()
 		}
 
+
 		if t1.Kind() == reflect.Struct {
 			fs, err := getStructFields(t1)
 			if err != nil {
 				return nil, fmt.Errorf("error processing embedded field: %v", err)
 			}
 			efields = mergeStructFields(efields, fs)
-		} else {
+		} else if (t1.Kind() >= reflect.Bool && t1.Kind() < reflect.Complex128) || t1.Kind() == reflect.String {
 			if strings.Contains(f.Name, ".") || unicode.IsUpper([]rune(f.Name)[0]) {
 				fields = append(fields, f)
 			}


### PR DESCRIPTION
When I use easyjson for my structs I get an error "_**cannot generate decoder for customTypes.DurationInSecond: error processing embedded field: got time.Duration; expected a struct**_".

This is a struct that causes an error.
```
type DurationInSeconds struct {
    time.Duration
}
func(dis DurationInSeconds) func1() {}
func(dis DurationInSeconds) func2() {}
```

So I explore the code of generator and improved func genStructFields.
Looks like it works on my project now (generated, compiled and tested on few structs).
I would like to run tests, but I can't figure out how to run them(I'm on Windows).