### PR TITLE
Add option to generate (un)marshal code for private fields

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,8 @@ generate: root build
 		.root/src/$(PKG)/tests/named_type.go \
 		.root/src/$(PKG)/tests/custom_map_key_type.go \
 		.root/src/$(PKG)/tests/embedded_type.go \
-		.root/src/$(PKG)/tests/reference_to_pointer.go
+		.root/src/$(PKG)/tests/reference_to_pointer.go \
+		.root/src/$(PKG)/tests/private_fields.go
 
 	.root/bin/easyjson -all .root/src/$(PKG)/tests/data.go
 	.root/bin/easyjson -all .root/src/$(PKG)/tests/nothing.go
@@ -40,6 +41,7 @@ generate: root build
 	.root/bin/easyjson .root/src/$(PKG)/tests/embedded_type.go
 	.root/bin/easyjson .root/src/$(PKG)/tests/reference_to_pointer.go
 	.root/bin/easyjson -disallow_unknown_fields .root/src/$(PKG)/tests/disallow_unknown.go
+	.root/bin/easyjson -include_private_fields .root/src/$(PKG)/tests/private_fields.go
 
 test: generate root
 	go test \

--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ Usage of easyjson:
     	only generate stubs for marshaler/unmarshaler funcs
   -disallow_unknown_fields
         return error if some unknown field in json appeared
+  -include_private_fields
+        generate marshal/unmarshal code for private fields of a struct
 ```
 
 Using `-all` will generate marshalers/unmarshalers for all Go structs in the

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -27,6 +27,7 @@ type Generator struct {
 	LowerCamelCase        bool
 	OmitEmpty             bool
 	DisallowUnknownFields bool
+	IncludePrivateFields  bool
 
 	OutName   string
 	BuildTags string
@@ -123,6 +124,9 @@ func (g *Generator) writeMain() (path string, err error) {
 	}
 	if g.DisallowUnknownFields {
 		fmt.Fprintln(f, "  g.DisallowUnknownFields()")
+	}
+	if g.IncludePrivateFields {
+		fmt.Fprintln(f, "  g.IncludePrivateFields()")
 	}
 
 	sort.Strings(g.Types)

--- a/easyjson/main.go
+++ b/easyjson/main.go
@@ -28,6 +28,7 @@ var noformat = flag.Bool("noformat", false, "do not run 'gofmt -w' on output fil
 var specifiedName = flag.String("output_filename", "", "specify the filename of the output")
 var processPkg = flag.Bool("pkg", false, "process the whole package instead of just the given file")
 var disallowUnknownFields = flag.Bool("disallow_unknown_fields", false, "return error if any unknown field in json appeared")
+var includePrivateFields = flag.Bool("include_private_fields", false, "generate marshal/unmarshal code for private fields of a struct")
 
 func generate(fname string) (err error) {
 	fInfo, err := os.Stat(fname)
@@ -69,6 +70,7 @@ func generate(fname string) (err error) {
 		LowerCamelCase:        *lowerCamelCase,
 		NoStdMarshalers:       *noStdMarshalers,
 		DisallowUnknownFields: *disallowUnknownFields,
+		IncludePrivateFields:  *includePrivateFields,
 		OmitEmpty:             *omitEmpty,
 		LeaveTemps:            *leaveTemps,
 		OutName:               outName,

--- a/gen/decoder.go
+++ b/gen/decoder.go
@@ -340,7 +340,7 @@ func mergeStructFields(fields1, fields2 []reflect.StructField) (fields []reflect
 	return
 }
 
-func getStructFields(t reflect.Type) ([]reflect.StructField, error) {
+func getStructFields(t reflect.Type, includePrivateFields bool) ([]reflect.StructField, error) {
 	if t.Kind() != reflect.Struct {
 		return nil, fmt.Errorf("got %v; expected a struct", t)
 	}
@@ -358,7 +358,7 @@ func getStructFields(t reflect.Type) ([]reflect.StructField, error) {
 			t1 = t1.Elem()
 		}
 
-		fs, err := getStructFields(t1)
+		fs, err := getStructFields(t1, includePrivateFields)
 		if err != nil {
 			return nil, fmt.Errorf("error processing embedded field: %v", err)
 		}
@@ -374,7 +374,7 @@ func getStructFields(t reflect.Type) ([]reflect.StructField, error) {
 		}
 
 		c := []rune(f.Name)[0]
-		if unicode.IsUpper(c) {
+		if includePrivateFields || unicode.IsUpper(c) {
 			fields = append(fields, f)
 		}
 	}
@@ -441,7 +441,7 @@ func (g *Generator) genStructDecoder(t reflect.Type) error {
 		fmt.Fprintln(g.out, "  out."+f.Name+" = new("+g.getType(f.Type.Elem())+")")
 	}
 
-	fs, err := getStructFields(t)
+	fs, err := getStructFields(t, g.includePrivateFields)
 	if err != nil {
 		return fmt.Errorf("cannot generate decoder for %v: %v", t, err)
 	}

--- a/gen/encoder.go
+++ b/gen/encoder.go
@@ -355,7 +355,7 @@ func (g *Generator) genStructEncoder(t reflect.Type) error {
 	fmt.Fprintln(g.out, "  first := true")
 	fmt.Fprintln(g.out, "  _ = first")
 
-	fs, err := getStructFields(t)
+	fs, err := getStructFields(t, g.includePrivateFields)
 	if err != nil {
 		return fmt.Errorf("cannot generate encoder for %v: %v", t, err)
 	}

--- a/gen/generator.go
+++ b/gen/generator.go
@@ -36,6 +36,7 @@ type Generator struct {
 	noStdMarshalers       bool
 	omitEmpty             bool
 	disallowUnknownFields bool
+	includePrivateFields  bool
 	fieldNamer            FieldNamer
 
 	// package path to local alias map for tracking imports
@@ -119,6 +120,11 @@ func (g *Generator) DisallowUnknownFields() {
 // OmitEmpty triggers `json=",omitempty"` behaviour by default.
 func (g *Generator) OmitEmpty() {
 	g.omitEmpty = true
+}
+
+// IncludePrivateFields instructs to include private struct fields.
+func (g *Generator) IncludePrivateFields() {
+	g.includePrivateFields = true
 }
 
 // addTypes requests to generate encoding/decoding funcs for the given type.

--- a/tests/basic_test.go
+++ b/tests/basic_test.go
@@ -52,6 +52,7 @@ var testCases = []struct {
 	{&intArrayStructValue, intArrayStructValueString},
 	{&myUInt8SliceValue, myUInt8SliceString},
 	{&myUInt8ArrayValue, myUInt8ArrayString},
+	{&myPrivateFieldStructValue, myPrivateFieldStructString},
 }
 
 func TestMarshal(t *testing.T) {

--- a/tests/private_fields.go
+++ b/tests/private_fields.go
@@ -1,0 +1,13 @@
+package tests
+
+//easyjson:json
+type PrivateFieldStruct struct {
+	name    string
+	process bool `json:"private_process"`
+	Public  bool
+}
+
+var (
+	myPrivateFieldStructValue  = PrivateFieldStruct{name: "hello", process: true, Public: true}
+	myPrivateFieldStructString = `{"name":"hello","private_process":true,"Public":true}`
+)


### PR DESCRIPTION
I really love easyjson and it's code generation the performance improvements are great!

One issue which has given me and others in my company some problems is that we use struct's for our eventsourced golang projects and they need to be serialized. 
Since these struct should not be changed we use private fields but this make us the easyjson generator hard to use (aka first use public fields then rename or use a patched easyjson).

This PR add the  `-include_private_fields` option to easyjson that allows the generator to create marshal and unmarshal code for private fields. I know that this is not in the stdlib but it would be a nice feature to add to easyjson in my opinion. 
Please let me know what you think and thanks in advance!