### PR TITLE
Issue #217: handling of _test.go files

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -5,6 +5,7 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
+	"os"
 	"os/exec"
 	"strings"
 )
@@ -73,7 +74,7 @@ func (p *Parser) Parse(fname string, isDir bool) error {
 
 	fset := token.NewFileSet()
 	if isDir {
-		packages, err := parser.ParseDir(fset, fname, nil, parser.ParseComments)
+		packages, err := parser.ParseDir(fset, fname, excludeTestFiles, parser.ParseComments)
 		if err != nil {
 			return err
 		}
@@ -95,4 +96,8 @@ func (p *Parser) Parse(fname string, isDir bool) error {
 func getDefaultGoPath() (string, error) {
 	output, err := exec.Command("go", "env", "GOPATH").Output()
 	return string(bytes.TrimSpace(output)), err
+}
+
+func excludeTestFiles(fi os.FileInfo) bool {
+	return !strings.HasSuffix(fi.Name(), "_test.go")
 }


### PR DESCRIPTION
If a directory is passed to the command line tool, the directory
includes test files, and those test files specify types that the tool is
interested in (e.g. struct types) then it will trigger a compiler error,
fail to generate, and leave some detritus in the target directory.

We should filter out test files from consideration to prevent this error
from occuring. Future development could include a command line option to
process test files, if anyone wants that (unlikely).