### PR TITLE
Bug with partition letter case removed

### DIFF
--- a/parser/pkgpath.go
+++ b/parser/pkgpath.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"path"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -151,8 +152,8 @@ func getPkgPathFromGOPATH(fname string, isDir bool) (string, error) {
 			return "", fmt.Errorf("cannot determine GOPATH: %s", err)
 		}
 	}
-
 	for _, p := range strings.Split(gopath, string(filepath.ListSeparator)) {
+		p = makePartitionNameUpperCaseOnWindows(p)
 		prefix := filepath.Join(p, "src") + string(filepath.Separator)
 		if rel := strings.TrimPrefix(fname, prefix); rel != fname {
 			if !isDir {
@@ -168,4 +169,16 @@ func getPkgPathFromGOPATH(fname string, isDir bool) (string, error) {
 
 func filePathToPackagePath(path string) string {
 	return filepath.ToSlash(path)
+}
+
+func makePartitionNameUpperCaseOnWindows(path string) string {
+	if runtime.GOOS != "windows" {
+		return path
+	}
+	parts := strings.Split(path, ":\\")
+	if len(parts) != 2 {
+		return path
+	}
+	partition := strings.ToUpper(parts[0])
+	return partition + ":\\" + parts[1]
 }


### PR DESCRIPTION
This is a bug with GOPATH and os.Getwd.
os.Getwd always returns path to directory with partition name in upper case (on Windows). Like that: `C:\Go\Projects\myproject`.
But GOPATH may have such form: `c:\Go\Projects`.
So, in code we use strings.TrimPrefix to determine, is our file in GOPATH or not. Cause of one letter in wrong case we cannot trim these two strings, but should.