### PR TITLE
Ignore build tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,13 @@ Additional option notes:
 
 * `-build_tags` will add the specified build tags to generated Go sources.
 
+## Excluded files
+
+While parsing the Go files the following files are getting excluded:
+
+* `_test.go` filename suffix
+* Files containing the build tag: `// +build ignore` (one white space in-between)
+
 ## Generated Marshaler/Unmarshaler Funcs
 
 For Go struct types, easyjson generates the funcs `MarshalEasyJSON` /

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -5,6 +5,7 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
+	"os"
 	"os/exec"
 	"strings"
 )
@@ -73,7 +74,7 @@ func (p *Parser) Parse(fname string, isDir bool) error {
 
 	fset := token.NewFileSet()
 	if isDir {
-		packages, err := parser.ParseDir(fset, fname, nil, parser.ParseComments)
+		packages, err := parser.ParseDir(fset, fname, excludeTestFiles, parser.ParseComments)
 		if err != nil {
 			return err
 		}
@@ -95,4 +96,8 @@ func (p *Parser) Parse(fname string, isDir bool) error {
 func getDefaultGoPath() (string, error) {
 	output, err := exec.Command("go", "env", "GOPATH").Output()
 	return string(bytes.TrimSpace(output)), err
+}
+
+func excludeTestFiles(fi os.FileInfo) bool {
+	return !strings.HasSuffix(fi.Name(), "_test.go")
 }


### PR DESCRIPTION
This version extends PR #218 based on issue #217 by also ignoring files which contain the build tag `// +build ignore`.

A better PR would add the new CLI flag `-tags` to provide the tags whose files must get included during parsing. Same as `go build -tags ...`. But the `-tags` flag for easyjson would be a breaking change.