### PR TITLE
Support extra/undefined fields in a struct

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,7 @@ generate: root build
 	.root/bin/easyjson -all .root/src/$(PKG)/tests/data.go
 	.root/bin/easyjson -all .root/src/$(PKG)/tests/nothing.go
 	.root/bin/easyjson -all .root/src/$(PKG)/tests/errors.go
+	.root/bin/easyjson -all .root/src/$(PKG)/tests/extra_fields_type.go
 	.root/bin/easyjson -snake_case .root/src/$(PKG)/tests/snake.go
 	.root/bin/easyjson -omit_empty .root/src/$(PKG)/tests/omitempty.go
 	.root/bin/easyjson -build_tags=use_easyjson .root/src/$(PKG)/benchmark/data.go

--- a/README.md
+++ b/README.md
@@ -101,6 +101,18 @@ utility funcs that are available.
 
 ## Controlling easyjson Marshaling and Unmarshaling Behavior
 
+easyjson recognises the `extra` tag as an extention, to support combinations of
+defined and undefined fields. Unmarshal puts any undefined field into an extra
+field map, when present. Marshal writes any undefined field from an extra field
+map, when present.
+
+```go
+type Flexible struct {
+	Field1      string
+	OtherFields map[string]interface{} `json:"-,extra"`
+}
+```
+
 Go types can provide their own `MarshalEasyJSON` and `UnmarshalEasyJSON` funcs
 that satisify the `easyjson.Marshaler` / `easyjson.Unmarshaler` interfaces.
 These will be used by `easyjson.Marshal` and `easyjson.Unmarshal` when defined

--- a/tests/extra_fields_test.go
+++ b/tests/extra_fields_test.go
@@ -1,0 +1,63 @@
+package tests
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestUnmarshalExtraFields(t *testing.T) {
+	golden := []struct {
+		Serial string
+		Object ExtraFieldsType
+	}{
+		{`{"Field1":1}`, ExtraFieldsType{Field1: 1,
+			Extra: nil,
+		}},
+		{`{"Field1":1,"FieldX":"2"}`, ExtraFieldsType{Field1: 1,
+			Extra: map[string]interface{}{"FieldX": "2"},
+		}},
+		{`{"FieldX":3}`, ExtraFieldsType{Field1: 0,
+			Extra: map[string]interface{}{"FieldX": 3.0},
+		}},
+	}
+
+	for _, gold := range golden {
+		var o ExtraFieldsType
+		err := o.UnmarshalJSON([]byte(gold.Serial))
+		if err != nil {
+			t.Errorf("unmarshal %s error: %s", gold.Serial, err)
+			continue
+		}
+		if !reflect.DeepEqual(o, gold.Object) {
+			t.Errorf("unmarshal %s got %#v, want %#v", gold.Serial, o, gold.Object)
+		}
+	}
+
+	for _, gold := range golden {
+		bytes, err := gold.Object.MarshalJSON()
+		if err != nil {
+			t.Errorf("marshal %#v error: %s", gold.Object, err)
+			continue
+		}
+		if string(bytes) != gold.Serial {
+			t.Errorf("unmarshal %#v got %s\nwant %s", gold.Object, bytes, gold.Serial)
+		}
+	}
+}
+
+func TestExtraFieldsOverride(t *testing.T) {
+	o := ExtraFieldsType{
+		Extra: map[string]interface{}{
+			"Field1": 42,
+			"f2":     99, // override custom name Field2
+			"Field3": 100,
+		},
+	}
+	bytes, err := o.MarshalJSON()
+	if err != nil {
+		t.Fatal("marshal error:", err)
+	}
+	if want := `{"Field3":100}`; string(bytes) != want {
+		t.Errorf("marshal %#v got %s\nwant %s", o, bytes, want)
+	}
+}

--- a/tests/extra_fields_type.go
+++ b/tests/extra_fields_type.go
@@ -1,0 +1,7 @@
+package tests
+
+type ExtraFieldsType struct {
+	Field1 int                    `json:",omitempty"`
+	Field2 int                    `json:"f2,omitempty"`
+	Extra  map[string]interface{} `json:"-,extra"`
+}


### PR DESCRIPTION
Quite a few JSON APIs and formats support a mixture of defined and undefined fields within a single object. When parsing twice, once in a struct, and once in a map[string]interface{}, then you need to take care of duplicates and such.