### PR TITLE
fix panic divide by zero

### DIFF
--- a/gen/decoder.go
+++ b/gen/decoder.go
@@ -124,9 +124,9 @@ func (g *Generator) genTypeDecoderNoCheck(t reflect.Type, out string, tags field
 
 		} else {
 
-			capacity := minSliceBytes / elem.Size()
-			if capacity == 0 {
-				capacity = 1
+			capacity := 1
+			if elem.Size() > 0 {
+				capacity = minSliceBytes / int(elem.Size())
 			}
 
 			fmt.Fprintln(g.out, ws+"if in.IsNull() {")


### PR DESCRIPTION
Fixes issue with

```
panic: runtime error: integer divide by zero

goroutine 1 [running]:
github.com/mailru/easyjson/gen.(*Generator).genTypeDecoderNoCheck(0xc0000b2b40, 0x8a7ce0, 0x789a60, 0xc0000d3a18, 0xf, 0x775e5c, 0xb, 0x0, 0x3, 0x1, ...)
        /home/user/go/pkg/mod/github.com/mailru/easyjson@v0.0.0-20190806181939-d838132d3919/gen/decoder.go:127 +0x5b9f
github.com/mailru/easyjson/gen.(*Generator).genTypeDecoder(0xc0000b2b40, 0x8a7ce0, 0x789a60, 0xc0000d3a18, 0xf, 0x775e5c, 0xb, 0x0, 0x3, 0x0, ...)
        /home/user/go/pkg/mod/github.com/mailru/easyjson@v0.0.0-20190806181939-d838132d3919/gen/decoder.go:85 +0x51e
github.com/mailru/easyjson/gen.(*Generator).genStructFieldDecoder(0xc0000b2b40, 0x8a7ce0, 0x8061e0, 0x775e49, 0xb, 0x0, 0x0, 0x8a7ce0, 0x789a60, 0x775e56, ...)
        /home/user/go/pkg/mod/github.com/mailru/easyjson@v0.0.0-20190806181939-d838132d3919/gen/decoder.go:298 +0x244
github.com/mailru/easyjson/gen.(*Generator).genStructDecoder(0xc0000b2b40, 0x8a7ce0, 0x8061e0, 0x790d20, 0xc0000b2d20)
        /home/user/go/pkg/mod/github.com/mailru/easyjson@v0.0.0-20190806181939-d838132d3919/gen/decoder.go:489 +0x1612
github.com/mailru/easyjson/gen.(*Generator).genDecoder(0xc0000b2b40, 0x8a7ce0, 0x8061e0, 0xc0000b2dac, 0x0)
        /home/user/go/pkg/mod/github.com/mailru/easyjson@v0.0.0-20190806181939-d838132d3919/gen/decoder.go:406 +0xb1
github.com/mailru/easyjson/gen.(*Generator).Run(0xc0000b2b40, 0x898520, 0xc0000aa008, 0xc0000d3f88, 0x40732f)
        /home/user/go/pkg/mod/github.com/mailru/easyjson@v0.0.0-20190806181939-d838132d3919/gen/generator.go:195 +0xe6
```
Should also fix https://github.com/mailru/easyjson/issues/108