### PR TITLE
fix unsafe `unsafe` usage

### DIFF
--- a/jlexer/bytestostr.go
+++ b/jlexer/bytestostr.go
@@ -8,7 +8,6 @@
 package jlexer
 
 import (
-	"reflect"
 	"unsafe"
 )
 
@@ -18,7 +17,5 @@ import (
 // chunk may be either blocked from being freed by GC because of a single string or the buffer.Data
 // may be garbage-collected even when the string exists.
 func bytesToStr(data []byte) string {
-	h := (*reflect.SliceHeader)(unsafe.Pointer(&data))
-	shdr := reflect.StringHeader{Data: h.Data, Len: h.Len}
-	return *(*string)(unsafe.Pointer(&shdr))
+	return *(*string)(unsafe.Pointer(&data))
 }


### PR DESCRIPTION
for the explanation, please refer to this PR https://github.com/go-redis/redis/pull/693