### PR TITLE
Allow empty maps for required map fields (issue #256)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.iml
 .idea
 *.swp
+bin/*

--- a/tests/data.go
+++ b/tests/data.go
@@ -678,6 +678,12 @@ type RequiredOptionalStruct struct {
 	Lastname  string `json:"last_name"`
 }
 
+type RequiredOptionalMap struct {
+	ReqMap         map[int]string `json:"req_map,required"`
+	OmitEmptyMap   map[int]string `json:"oe_map,omitempty"`
+	NoOmitEmptyMap map[int]string `json:"noe_map,!omitempty"`
+}
+
 //easyjson:json
 type EncodingFlagsTestMap struct {
 	F map[string]string

--- a/tests/required_test.go
+++ b/tests/required_test.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"fmt"
+	"reflect"
 	"testing"
 )
 
@@ -24,5 +25,27 @@ func TestRequiredField(t *testing.T) {
 				t.Errorf("%s. UnmarshalJSON expected error: %v. got: %v", tc.json, tc.errorMessage, err)
 			}
 		}
+	}
+}
+
+func TestRequiredOptionalMap(t *testing.T) {
+	baseJson := `{"req_map":{}, "oe_map":{}, "noe_map":{}, "oe_slice":[]}`
+	wantDecoding := RequiredOptionalMap{MapIntString{}, nil, MapIntString{}}
+
+	var v RequiredOptionalMap
+	if err := v.UnmarshalJSON([]byte(baseJson)); err != nil {
+		t.Errorf("%s. UnmarshalJSON didn't expect error: %v", baseJson, err)
+	}
+	if !reflect.DeepEqual(v, wantDecoding) {
+		t.Errorf("%s. UnmarshalJSON expected to gen: %v. got: %v", baseJson, wantDecoding, v)
+	}
+
+	baseStruct := RequiredOptionalMap{MapIntString{}, MapIntString{}, MapIntString{}}
+	wantJson := `{"req_map":{},"noe_map":{}}`
+	data, err := baseStruct.MarshalJSON()
+	if err != nil {
+		t.Errorf("MarshalJSON didn't expect error: %v on %v", err, data)
+	} else if string(data) != wantJson {
+		t.Errorf("%v. MarshalJSON wanted: %s got %s", baseStruct, wantJson, string(data))
 	}
 }


### PR DESCRIPTION
As reported in issue #256, currently, an empty map is unmarshalled into nil by easyjson
If a field is marked "required" or "!omitempty", then the empty map is a valid input and
we should unmarshal it into an empty map.

Similar logic for marshalling.

This change is to fix the behavior