### PR TITLE
Make Buffer.EnsureSpace inlineable

### DIFF
--- a/buffer/pool.go
+++ b/buffer/pool.go
@@ -78,9 +78,12 @@ type Buffer struct {
 // EnsureSpace makes sure that the current chunk contains at least s free bytes,
 // possibly creating a new chunk.
 func (b *Buffer) EnsureSpace(s int) {
-	if cap(b.Buf)-len(b.Buf) >= s {
-		return
+	if cap(b.Buf)-len(b.Buf) < s {
+		b.ensureSpaceSlow(s)
 	}
+}
+
+func (b *Buffer) ensureSpaceSlow(s int) {
 	l := len(b.Buf)
 	if l > 0 {
 		if cap(b.toPool) != cap(b.Buf) {
@@ -105,18 +108,14 @@ func (b *Buffer) EnsureSpace(s int) {
 
 // AppendByte appends a single byte to buffer.
 func (b *Buffer) AppendByte(data byte) {
-	if cap(b.Buf) == len(b.Buf) { // EnsureSpace won't be inlined.
-		b.EnsureSpace(1)
-	}
+	b.EnsureSpace(1)
 	b.Buf = append(b.Buf, data)
 }
 
 // AppendBytes appends a byte slice to buffer.
 func (b *Buffer) AppendBytes(data []byte) {
 	for len(data) > 0 {
-		if cap(b.Buf) == len(b.Buf) { // EnsureSpace won't be inlined.
-			b.EnsureSpace(1)
-		}
+		b.EnsureSpace(1)
 
 		sz := cap(b.Buf) - len(b.Buf)
 		if sz > len(data) {
@@ -131,9 +130,7 @@ func (b *Buffer) AppendBytes(data []byte) {
 // AppendBytes appends a string to buffer.
 func (b *Buffer) AppendString(data string) {
 	for len(data) > 0 {
-		if cap(b.Buf) == len(b.Buf) { // EnsureSpace won't be inlined.
-			b.EnsureSpace(1)
-		}
+		b.EnsureSpace(1)
 
 		sz := cap(b.Buf) - len(b.Buf)
 		if sz > len(data) {


### PR DESCRIPTION
Split the slow path into a separate function, so that the fast path in EnsureSpace becomes inlineable.

This allows code in jwriter to inline the fast path.

```
name                              old time/op    new time/op    delta
EJ_Unmarshal_M-4                    33.4µs ± 1%    34.3µs ± 6%  +2.93%  (p=0.002 n=8+10)
EJ_Unmarshal_S-4                     462ns ± 0%     462ns ± 1%    ~     (p=0.994 n=9+10)
EJ_Marshal_M-4                      12.4µs ± 1%    11.6µs ± 1%  -6.60%  (p=0.000 n=9+9)
EJ_Marshal_L-4                       585µs ± 1%     586µs ± 1%    ~     (p=0.739 n=10+10)
EJ_Marshal_L_ToWriter-4              507µs ± 2%     511µs ± 9%    ~     (p=1.000 n=10+10)
EJ_Marshal_M_Parallel-4             3.73µs ± 2%    3.58µs ± 3%  -4.06%  (p=0.000 n=10+10)
EJ_Marshal_M_ToWriter-4             11.1µs ± 3%    10.2µs ± 1%  -7.69%  (p=0.000 n=10+9)
EJ_Marshal_M_ToWriter_Parallel-4    2.91µs ± 2%    2.96µs ± 4%    ~     (p=0.363 n=10+10)
EJ_Marshal_L_Parallel-4              195µs ± 0%     197µs ± 1%  +0.80%  (p=0.008 n=6+9)
EJ_Marshal_L_ToWriter_Parallel-4     145µs ± 1%     138µs ± 2%  -4.46%  (p=0.000 n=10+10)
EJ_Marshal_S-4                       160ns ± 1%     158ns ± 1%  -1.31%  (p=0.000 n=10+10)
EJ_Marshal_S_Parallel-4             56.1ns ± 1%    54.3ns ± 1%  -3.35%  (p=0.000 n=10+10)

name                              old speed      new speed      delta
EJ_Unmarshal_M-4                   389MB/s ± 4%   380MB/s ± 6%  -2.34%  (p=0.013 n=9+10)
EJ_Unmarshal_S-4                   177MB/s ± 0%   177MB/s ± 1%    ~     (p=0.859 n=9+10)
EJ_Marshal_M-4                     719MB/s ± 1%   770MB/s ± 1%  +7.07%  (p=0.000 n=9+9)
EJ_Marshal_L-4                     764MB/s ± 1%   764MB/s ± 1%    ~     (p=0.739 n=10+10)
EJ_Marshal_L_ToWriter-4            883MB/s ± 2%   877MB/s ± 8%    ~     (p=1.000 n=10+10)
EJ_Marshal_M_Parallel-4           3.49GB/s ± 2%  3.64GB/s ± 3%  +4.24%  (p=0.000 n=10+10)
EJ_Marshal_M_ToWriter-4            809MB/s ± 4%   877MB/s ± 1%  +8.30%  (p=0.000 n=10+9)
EJ_Marshal_M_ToWriter_Parallel-4  3.07GB/s ± 2%  3.02GB/s ± 4%    ~     (p=0.353 n=10+10)
EJ_Marshal_L_Parallel-4           2.29GB/s ± 0%  2.27GB/s ± 1%  -0.79%  (p=0.008 n=6+9)
EJ_Marshal_L_ToWriter_Parallel-4  3.09GB/s ± 1%  3.24GB/s ± 1%  +4.67%  (p=0.000 n=10+10)
EJ_Marshal_S-4                     507MB/s ± 1%   514MB/s ± 1%  +1.43%  (p=0.000 n=10+10)
EJ_Marshal_S_Parallel-4           1.44GB/s ± 1%  1.49GB/s ± 1%  +3.47%  (p=0.000 n=10+10)

name                              old alloc/op   new alloc/op   delta
EJ_Unmarshal_M-4                    9.79kB ± 0%    9.79kB ± 0%    ~     (all equal)
EJ_Unmarshal_S-4                      128B ± 0%      128B ± 0%    ~     (all equal)
EJ_Marshal_M-4                      10.4kB ± 0%    10.3kB ± 0%  -0.02%  (p=0.002 n=10+10)
EJ_Marshal_L-4                       457kB ± 0%     456kB ± 0%  -0.22%  (p=0.000 n=10+9)
EJ_Marshal_L_ToWriter-4             2.36kB ± 1%    2.37kB ± 1%    ~     (p=0.533 n=10+10)
EJ_Marshal_M_Parallel-4             10.2kB ± 0%    10.2kB ± 0%    ~     (p=0.858 n=7+10)
EJ_Marshal_M_ToWriter-4               737B ± 0%      737B ± 0%    ~     (p=0.137 n=8+10)
EJ_Marshal_M_ToWriter_Parallel-4      739B ± 0%      739B ± 0%    ~     (p=0.248 n=10+9)
EJ_Marshal_L_Parallel-4              463kB ± 0%     464kB ± 0%  +0.30%  (p=0.000 n=10+10)
EJ_Marshal_L_ToWriter_Parallel-4    2.41kB ± 1%    2.41kB ± 1%    ~     (p=0.926 n=10+10)
EJ_Marshal_S-4                        128B ± 0%      128B ± 0%    ~     (all equal)
EJ_Marshal_S_Parallel-4               128B ± 0%      128B ± 0%    ~     (all equal)

name                              old allocs/op  new allocs/op  delta
EJ_Unmarshal_M-4                       128 ± 0%       128 ± 0%    ~     (all equal)
EJ_Unmarshal_S-4                      3.00 ± 0%      3.00 ± 0%    ~     (all equal)
EJ_Marshal_M-4                        10.0 ± 0%      10.0 ± 0%    ~     (all equal)
EJ_Marshal_L-4                        29.0 ± 0%      28.0 ± 0%  -3.45%  (p=0.000 n=10+9)
EJ_Marshal_L_ToWriter-4               24.0 ± 0%      24.0 ± 0%    ~     (all equal)
EJ_Marshal_M_Parallel-4               9.00 ± 0%      9.00 ± 0%    ~     (all equal)
EJ_Marshal_M_ToWriter-4               8.00 ± 0%      8.00 ± 0%    ~     (all equal)
EJ_Marshal_M_ToWriter_Parallel-4      8.00 ± 0%      8.00 ± 0%    ~     (all equal)
EJ_Marshal_L_Parallel-4               31.0 ± 0%      31.0 ± 0%    ~     (all equal)
EJ_Marshal_L_ToWriter_Parallel-4      24.0 ± 0%      24.0 ± 0%    ~     (all equal)
EJ_Marshal_S-4                        1.00 ± 0%      1.00 ± 0%    ~     (all equal)
EJ_Marshal_S_Parallel-4               1.00 ± 0%      1.00 ± 0%    ~     (all equal)name                              old time/op    new time/op    delta
EJ_Unmarshal_M-4                    33.4µs ± 1%    34.3µs ± 6%  +2.93%  (p=0.002 n=8+10)
EJ_Unmarshal_S-4                     462ns ± 0%     462ns ± 1%    ~     (p=0.994 n=9+10)
EJ_Marshal_M-4                      12.4µs ± 1%    11.6µs ± 1%  -6.60%  (p=0.000 n=9+9)
EJ_Marshal_L-4                       585µs ± 1%     586µs ± 1%    ~     (p=0.739 n=10+10)
EJ_Marshal_L_ToWriter-4              507µs ± 2%     511µs ± 9%    ~     (p=1.000 n=10+10)
EJ_Marshal_M_Parallel-4             3.73µs ± 2%    3.58µs ± 3%  -4.06%  (p=0.000 n=10+10)
EJ_Marshal_M_ToWriter-4             11.1µs ± 3%    10.2µs ± 1%  -7.69%  (p=0.000 n=10+9)
EJ_Marshal_M_ToWriter_Parallel-4    2.91µs ± 2%    2.96µs ± 4%    ~     (p=0.363 n=10+10)
EJ_Marshal_L_Parallel-4              195µs ± 0%     197µs ± 1%  +0.80%  (p=0.008 n=6+9)
EJ_Marshal_L_ToWriter_Parallel-4     145µs ± 1%     138µs ± 2%  -4.46%  (p=0.000 n=10+10)
EJ_Marshal_S-4                       160ns ± 1%     158ns ± 1%  -1.31%  (p=0.000 n=10+10)
EJ_Marshal_S_Parallel-4             56.1ns ± 1%    54.3ns ± 1%  -3.35%  (p=0.000 n=10+10)

name                              old speed      new speed      delta
EJ_Unmarshal_M-4                   389MB/s ± 4%   380MB/s ± 6%  -2.34%  (p=0.013 n=9+10)
EJ_Unmarshal_S-4                   177MB/s ± 0%   177MB/s ± 1%    ~     (p=0.859 n=9+10)
EJ_Marshal_M-4                     719MB/s ± 1%   770MB/s ± 1%  +7.07%  (p=0.000 n=9+9)
EJ_Marshal_L-4                     764MB/s ± 1%   764MB/s ± 1%    ~     (p=0.739 n=10+10)
EJ_Marshal_L_ToWriter-4            883MB/s ± 2%   877MB/s ± 8%    ~     (p=1.000 n=10+10)
EJ_Marshal_M_Parallel-4           3.49GB/s ± 2%  3.64GB/s ± 3%  +4.24%  (p=0.000 n=10+10)
EJ_Marshal_M_ToWriter-4            809MB/s ± 4%   877MB/s ± 1%  +8.30%  (p=0.000 n=10+9)
EJ_Marshal_M_ToWriter_Parallel-4  3.07GB/s ± 2%  3.02GB/s ± 4%    ~     (p=0.353 n=10+10)
EJ_Marshal_L_Parallel-4           2.29GB/s ± 0%  2.27GB/s ± 1%  -0.79%  (p=0.008 n=6+9)
EJ_Marshal_L_ToWriter_Parallel-4  3.09GB/s ± 1%  3.24GB/s ± 1%  +4.67%  (p=0.000 n=10+10)
EJ_Marshal_S-4                     507MB/s ± 1%   514MB/s ± 1%  +1.43%  (p=0.000 n=10+10)
EJ_Marshal_S_Parallel-4           1.44GB/s ± 1%  1.49GB/s ± 1%  +3.47%  (p=0.000 n=10+10)

name                              old alloc/op   new alloc/op   delta
EJ_Unmarshal_M-4                    9.79kB ± 0%    9.79kB ± 0%    ~     (all equal)
EJ_Unmarshal_S-4                      128B ± 0%      128B ± 0%    ~     (all equal)
EJ_Marshal_M-4                      10.4kB ± 0%    10.3kB ± 0%  -0.02%  (p=0.002 n=10+10)
EJ_Marshal_L-4                       457kB ± 0%     456kB ± 0%  -0.22%  (p=0.000 n=10+9)
EJ_Marshal_L_ToWriter-4             2.36kB ± 1%    2.37kB ± 1%    ~     (p=0.533 n=10+10)
EJ_Marshal_M_Parallel-4             10.2kB ± 0%    10.2kB ± 0%    ~     (p=0.858 n=7+10)
EJ_Marshal_M_ToWriter-4               737B ± 0%      737B ± 0%    ~     (p=0.137 n=8+10)
EJ_Marshal_M_ToWriter_Parallel-4      739B ± 0%      739B ± 0%    ~     (p=0.248 n=10+9)
EJ_Marshal_L_Parallel-4              463kB ± 0%     464kB ± 0%  +0.30%  (p=0.000 n=10+10)
EJ_Marshal_L_ToWriter_Parallel-4    2.41kB ± 1%    2.41kB ± 1%    ~     (p=0.926 n=10+10)
EJ_Marshal_S-4                        128B ± 0%      128B ± 0%    ~     (all equal)
EJ_Marshal_S_Parallel-4               128B ± 0%      128B ± 0%    ~     (all equal)

name                              old allocs/op  new allocs/op  delta
EJ_Unmarshal_M-4                       128 ± 0%       128 ± 0%    ~     (all equal)
EJ_Unmarshal_S-4                      3.00 ± 0%      3.00 ± 0%    ~     (all equal)
EJ_Marshal_M-4                        10.0 ± 0%      10.0 ± 0%    ~     (all equal)
EJ_Marshal_L-4                        29.0 ± 0%      28.0 ± 0%  -3.45%  (p=0.000 n=10+9)
EJ_Marshal_L_ToWriter-4               24.0 ± 0%      24.0 ± 0%    ~     (all equal)
EJ_Marshal_M_Parallel-4               9.00 ± 0%      9.00 ± 0%    ~     (all equal)
EJ_Marshal_M_ToWriter-4               8.00 ± 0%      8.00 ± 0%    ~     (all equal)
EJ_Marshal_M_ToWriter_Parallel-4      8.00 ± 0%      8.00 ± 0%    ~     (all equal)
EJ_Marshal_L_Parallel-4               31.0 ± 0%      31.0 ± 0%    ~     (all equal)
EJ_Marshal_L_ToWriter_Parallel-4      24.0 ± 0%      24.0 ± 0%    ~     (all equal)
EJ_Marshal_S-4                        1.00 ± 0%      1.00 ± 0%    ~     (all equal)
EJ_Marshal_S_Parallel-4               1.00 ± 0%      1.00 ± 0%    ~     (all equal)
```