### PR TITLE
Make Buffer.Append{String,Bytes} inlineable

### DIFF
--- a/buffer/pool.go
+++ b/buffer/pool.go
@@ -113,6 +113,14 @@ func (b *Buffer) AppendByte(data byte) {
 
 // AppendBytes appends a byte slice to buffer.
 func (b *Buffer) AppendBytes(data []byte) {
+	if len(data) <= cap(b.Buf)-len(b.Buf) {
+		b.Buf = append(b.Buf, data...) // fast path
+	} else {
+		b.appendBytesSlow(data)
+	}
+}
+
+func (b *Buffer) appendBytesSlow(data []byte) {
 	for len(data) > 0 {
 		if cap(b.Buf) == len(b.Buf) { // EnsureSpace won't be inlined.
 			b.EnsureSpace(1)
@@ -128,8 +136,16 @@ func (b *Buffer) AppendBytes(data []byte) {
 	}
 }
 
-// AppendBytes appends a string to buffer.
+// AppendString appends a string to buffer.
 func (b *Buffer) AppendString(data string) {
+	if len(data) <= cap(b.Buf)-len(b.Buf) {
+		b.Buf = append(b.Buf, data...) // fast path
+	} else {
+		b.appendStringSlow(data)
+	}
+}
+
+func (b *Buffer) appendStringSlow(data string) {
 	for len(data) > 0 {
 		if cap(b.Buf) == len(b.Buf) { // EnsureSpace won't be inlined.
 			b.EnsureSpace(1)

--- a/buffer/pool_test.go
+++ b/buffer/pool_test.go
@@ -42,7 +42,7 @@ func TestAppendString(t *testing.T) {
 
 	s := "test"
 	for i := 0; i < 1000; i++ {
-		b.AppendBytes([]byte(s))
+		b.AppendString(s)
 		want = append(want, s...)
 	}
 


### PR DESCRIPTION
Allow to inline the fast path of AppendString and AppendBytes.

Also fix a related test and some copy-pasted comments.

```
name                              old time/op    new time/op    delta
EJ_Unmarshal_M-4                    33.3µs ± 1%    33.6µs ± 3%     ~     (p=0.095 n=9+10)
EJ_Unmarshal_S-4                     462ns ± 0%     465ns ± 1%     ~     (p=0.084 n=8+9)
EJ_Marshal_M-4                      12.4µs ± 1%    10.9µs ± 2%  -12.11%  (p=0.000 n=10+9)
EJ_Marshal_L-4                       586µs ± 1%     522µs ± 1%  -10.96%  (p=0.000 n=9+10)
EJ_Marshal_L_ToWriter-4              505µs ± 3%     428µs ± 5%  -15.31%  (p=0.000 n=10+9)
EJ_Marshal_M_Parallel-4             3.75µs ± 1%    3.32µs ± 2%  -11.45%  (p=0.000 n=10+10)
EJ_Marshal_M_ToWriter-4             11.0µs ± 2%     9.6µs ± 4%  -12.55%  (p=0.000 n=10+10)
EJ_Marshal_M_ToWriter_Parallel-4    2.92µs ± 2%    2.50µs ± 2%  -14.35%  (p=0.000 n=10+10)
EJ_Marshal_L_Parallel-4              193µs ± 2%     181µs ± 4%   -6.22%  (p=0.000 n=10+10)
EJ_Marshal_L_ToWriter_Parallel-4     145µs ± 3%     121µs ± 2%  -16.46%  (p=0.000 n=10+10)
EJ_Marshal_S-4                       161ns ± 3%     154ns ± 1%   -4.60%  (p=0.000 n=10+10)
EJ_Marshal_S_Parallel-4             56.2ns ± 1%    52.9ns ± 1%   -5.89%  (p=0.000 n=10+10)

name                              old speed      new speed      delta
EJ_Unmarshal_M-4                   392MB/s ± 1%   388MB/s ± 3%     ~     (p=0.095 n=9+10)
EJ_Unmarshal_S-4                   177MB/s ± 0%   176MB/s ± 1%     ~     (p=0.226 n=8+9)
EJ_Marshal_M-4                     720MB/s ± 1%   819MB/s ± 2%  +13.77%  (p=0.000 n=10+9)
EJ_Marshal_L-4                     763MB/s ± 1%   857MB/s ± 1%  +12.31%  (p=0.000 n=9+10)
EJ_Marshal_L_ToWriter-4            885MB/s ± 3%  1046MB/s ± 5%  +18.11%  (p=0.000 n=10+9)
EJ_Marshal_M_Parallel-4           3.48GB/s ± 1%  3.93GB/s ± 2%  +12.95%  (p=0.000 n=10+10)
EJ_Marshal_M_ToWriter-4            812MB/s ± 2%   929MB/s ± 4%  +14.40%  (p=0.000 n=10+10)
EJ_Marshal_M_ToWriter_Parallel-4  3.07GB/s ± 3%  3.58GB/s ± 2%  +16.74%  (p=0.000 n=10+10)
EJ_Marshal_L_Parallel-4           2.32GB/s ± 2%  2.48GB/s ± 4%   +6.65%  (p=0.000 n=10+10)
EJ_Marshal_L_ToWriter_Parallel-4  3.08GB/s ± 3%  3.69GB/s ± 2%  +19.69%  (p=0.000 n=10+10)
EJ_Marshal_S-4                     503MB/s ± 2%   528MB/s ± 1%   +4.95%  (p=0.000 n=10+10)
EJ_Marshal_S_Parallel-4           1.44GB/s ± 1%  1.53GB/s ± 1%   +6.30%  (p=0.000 n=10+10)

name                              old alloc/op   new alloc/op   delta
EJ_Unmarshal_M-4                    9.79kB ± 0%    9.79kB ± 0%     ~     (all equal)
EJ_Unmarshal_S-4                      128B ± 0%      128B ± 0%     ~     (all equal)
EJ_Marshal_M-4                      10.3kB ± 0%    10.3kB ± 0%   -0.01%  (p=0.008 n=10+10)
EJ_Marshal_L-4                       457kB ± 0%     457kB ± 0%   -0.08%  (p=0.000 n=10+7)
EJ_Marshal_L_ToWriter-4             2.37kB ± 1%    2.37kB ± 1%     ~     (p=0.209 n=10+10)
EJ_Marshal_M_Parallel-4             10.2kB ± 0%    10.2kB ± 0%     ~     (p=0.739 n=10+10)
EJ_Marshal_M_ToWriter-4               737B ± 0%      737B ± 0%   -0.05%  (p=0.046 n=10+8)
EJ_Marshal_M_ToWriter_Parallel-4      739B ± 0%      739B ± 0%     ~     (p=0.087 n=10+10)
EJ_Marshal_L_Parallel-4              463kB ± 0%     464kB ± 0%   +0.26%  (p=0.000 n=10+10)
EJ_Marshal_L_ToWriter_Parallel-4    2.41kB ± 1%    2.41kB ± 1%     ~     (p=0.684 n=10+10)
EJ_Marshal_S-4                        128B ± 0%      128B ± 0%     ~     (all equal)
EJ_Marshal_S_Parallel-4               128B ± 0%      128B ± 0%     ~     (all equal)

name                              old allocs/op  new allocs/op  delta
EJ_Unmarshal_M-4                       128 ± 0%       128 ± 0%     ~     (all equal)
EJ_Unmarshal_S-4                      3.00 ± 0%      3.00 ± 0%     ~     (all equal)
EJ_Marshal_M-4                        10.0 ± 0%      10.0 ± 0%     ~     (all equal)
EJ_Marshal_L-4                        29.0 ± 0%      28.7 ± 2%     ~     (p=0.173 n=9+10)
EJ_Marshal_L_ToWriter-4               24.0 ± 0%      24.0 ± 0%     ~     (all equal)
EJ_Marshal_M_Parallel-4               9.00 ± 0%      9.00 ± 0%     ~     (all equal)
EJ_Marshal_M_ToWriter-4               8.00 ± 0%      8.00 ± 0%     ~     (all equal)
EJ_Marshal_M_ToWriter_Parallel-4      8.00 ± 0%      8.00 ± 0%     ~     (all equal)
EJ_Marshal_L_Parallel-4               31.0 ± 0%      31.0 ± 0%     ~     (all equal)
EJ_Marshal_L_ToWriter_Parallel-4      24.0 ± 0%      24.0 ± 0%     ~     (all equal)
EJ_Marshal_S-4                        1.00 ± 0%      1.00 ± 0%     ~     (all equal)
EJ_Marshal_S_Parallel-4               1.00 ± 0%      1.00 ± 0%     ~     (all equal)
```