### PR TITLE
Do not copy escape tables

### DIFF
--- a/jwriter/writer.go
+++ b/jwriter/writer.go
@@ -297,11 +297,9 @@ func (w *Writer) String(s string) {
 
 	p := 0 // last non-escape symbol
 
-	var escapeTable [128]bool
+	escapeTable := &htmlEscapeTable
 	if w.NoEscapeHTML {
-		escapeTable = htmlNoEscapeTable
-	} else {
-		escapeTable = htmlEscapeTable
+		escapeTable = &htmlNoEscapeTable
 	}
 
 	for i := 0; i < len(s); {


### PR DESCRIPTION
Reference the escape tables by pointer, instead of allocating 128 bytes on the stack and copying the full table for every call to Writer.String

```
name                              old time/op    new time/op    delta
EJ_Unmarshal_M-4                    33.6µs ± 1%    34.3µs ± 5%   +2.00%  (p=0.006 n=9+10)
EJ_Unmarshal_S-4                     458ns ± 2%     464ns ± 5%     ~     (p=0.397 n=10+10)
EJ_Marshal_M-4                      11.8µs ± 1%    11.4µs ± 1%   -3.25%  (p=0.000 n=10+9)
EJ_Marshal_L-4                       577µs ± 1%     535µs ± 1%   -7.30%  (p=0.000 n=9+10)
EJ_Marshal_L_ToWriter-4              508µs ±13%     446µs ± 2%  -12.38%  (p=0.000 n=10+9)
EJ_Marshal_M_Parallel-4             4.26µs ±10%    4.17µs ± 4%     ~     (p=0.226 n=9+8)
EJ_Marshal_M_ToWriter-4             10.3µs ± 4%     9.9µs ± 1%   -3.92%  (p=0.000 n=10+10)
EJ_Marshal_M_ToWriter_Parallel-4    2.77µs ± 1%    2.68µs ± 2%   -3.31%  (p=0.000 n=7+10)
EJ_Marshal_L_Parallel-4              201µs ± 3%     193µs ± 1%   -3.73%  (p=0.000 n=10+9)
EJ_Marshal_L_ToWriter_Parallel-4     136µs ± 0%     129µs ± 1%   -4.75%  (p=0.000 n=7+9)
EJ_Marshal_S-4                       159ns ± 2%     152ns ± 1%   -4.52%  (p=0.000 n=10+9)
EJ_Marshal_S_Parallel-4             60.2ns ± 1%    58.0ns ± 4%   -3.71%  (p=0.000 n=7+10)

name                              old speed      new speed      delta
EJ_Unmarshal_M-4                   387MB/s ± 1%   380MB/s ± 5%   -1.92%  (p=0.006 n=9+10)
EJ_Unmarshal_S-4                   179MB/s ± 2%   177MB/s ± 4%     ~     (p=0.315 n=10+10)
EJ_Marshal_M-4                     759MB/s ± 1%   785MB/s ± 1%   +3.36%  (p=0.000 n=10+9)
EJ_Marshal_L-4                     775MB/s ± 1%   836MB/s ± 1%   +7.88%  (p=0.000 n=9+10)
EJ_Marshal_L_ToWriter-4            883MB/s ±12%  1004MB/s ± 2%  +13.79%  (p=0.000 n=10+9)
EJ_Marshal_M_Parallel-4           3.01GB/s ±17%  3.12GB/s ± 4%     ~     (p=0.146 n=10+8)
EJ_Marshal_M_ToWriter-4            868MB/s ± 4%   904MB/s ± 1%   +4.06%  (p=0.000 n=10+10)
EJ_Marshal_M_ToWriter_Parallel-4  3.23GB/s ± 1%  3.34GB/s ± 2%   +3.43%  (p=0.000 n=7+10)
EJ_Marshal_L_Parallel-4           2.23GB/s ± 3%  2.32GB/s ± 1%   +3.85%  (p=0.000 n=10+9)
EJ_Marshal_L_ToWriter_Parallel-4  3.30GB/s ± 0%  3.46GB/s ± 1%   +4.99%  (p=0.000 n=7+9)
EJ_Marshal_S-4                     508MB/s ± 2%   533MB/s ± 1%   +4.90%  (p=0.000 n=10+9)
EJ_Marshal_S_Parallel-4           1.34GB/s ± 1%  1.40GB/s ± 4%   +3.96%  (p=0.000 n=7+10)

name                              old alloc/op   new alloc/op   delta
EJ_Unmarshal_M-4                    9.79kB ± 0%    9.79kB ± 0%     ~     (all equal)
EJ_Unmarshal_S-4                      128B ± 0%      128B ± 0%     ~     (all equal)
EJ_Marshal_M-4                      10.4kB ± 0%    10.4kB ± 0%     ~     (p=0.898 n=10+9)
EJ_Marshal_L-4                       457kB ± 0%     457kB ± 0%     ~     (p=0.971 n=10+10)
EJ_Marshal_L_ToWriter-4             2.38kB ± 2%    2.36kB ± 1%     ~     (p=0.167 n=10+10)
EJ_Marshal_M_Parallel-4             10.2kB ± 0%    10.3kB ± 0%   +0.01%  (p=0.005 n=10+10)
EJ_Marshal_M_ToWriter-4               738B ± 0%      738B ± 0%     ~     (all equal)
EJ_Marshal_M_ToWriter_Parallel-4      739B ± 0%      739B ± 0%     ~     (p=0.294 n=10+8)
EJ_Marshal_L_Parallel-4              462kB ± 0%     462kB ± 0%   -0.04%  (p=0.043 n=10+10)
EJ_Marshal_L_ToWriter_Parallel-4    2.40kB ± 1%    2.40kB ± 1%     ~     (p=0.617 n=10+10)
EJ_Marshal_S-4                        128B ± 0%      128B ± 0%     ~     (all equal)
EJ_Marshal_S_Parallel-4               128B ± 0%      128B ± 0%     ~     (all equal)

name                              old allocs/op  new allocs/op  delta
EJ_Unmarshal_M-4                       128 ± 0%       128 ± 0%     ~     (all equal)
EJ_Unmarshal_S-4                      3.00 ± 0%      3.00 ± 0%     ~     (all equal)
EJ_Marshal_M-4                        10.0 ± 0%      10.0 ± 0%     ~     (all equal)
EJ_Marshal_L-4                        29.0 ± 0%      29.0 ± 0%     ~     (all equal)
EJ_Marshal_L_ToWriter-4               24.0 ± 0%      24.0 ± 0%     ~     (all equal)
EJ_Marshal_M_Parallel-4               9.00 ± 0%      9.00 ± 0%     ~     (all equal)
EJ_Marshal_M_ToWriter-4               8.00 ± 0%      8.00 ± 0%     ~     (all equal)
EJ_Marshal_M_ToWriter_Parallel-4      8.00 ± 0%      8.00 ± 0%     ~     (all equal)
EJ_Marshal_L_Parallel-4               31.0 ± 0%      31.0 ± 0%     ~     (all equal)
EJ_Marshal_L_ToWriter_Parallel-4      24.0 ± 0%      24.0 ± 0%     ~     (all equal)
EJ_Marshal_S-4                        1.00 ± 0%      1.00 ± 0%     ~     (all equal)
EJ_Marshal_S_Parallel-4               1.00 ± 0%      1.00 ± 0%     ~     (all equal)
```