### PR TITLE
Implement optional string interning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,8 @@ generate: build
 		./tests/reference_to_pointer.go \
 		./tests/html.go \
 		./tests/unknown_fields.go \
-		./tests/type_declaration.go
+		./tests/type_declaration.go \
+		./tests/intern.go
 
 	bin/easyjson -all ./tests/data.go
 	bin/easyjson -all ./tests/nothing.go
@@ -38,6 +39,7 @@ generate: build
 	bin/easyjson -disallow_unknown_fields ./tests/disallow_unknown.go
 	bin/easyjson ./tests/unknown_fields.go
 	bin/easyjson ./tests/type_declaration.go
+	bin/easyjson ./tests/intern.go
 
 test: generate
 	go test \

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ During unmarshaling, `string` field values can be optionally
 allocations and usage by deduplicating strings in memory, at the expense of slightly
 increased CPU usage.
 
-This will work effectively only for `string` fields being decoded have frequently
+This will work effectively only for `string` fields being decoded that have frequently
 the same value (e.g. if you have a string field that can only assume a small number
 of possible values).
 

--- a/README.md
+++ b/README.md
@@ -135,6 +135,27 @@ through a call to `buffer.Init()` prior to any marshaling or unmarshaling.
 Please see the [GoDoc listing](https://godoc.org/github.com/mailru/easyjson/buffer)
 for more information.
 
+## String interning
+
+During unmarshaling, `string` field values can be optionally
+[interned](https://en.wikipedia.org/wiki/String_interning) to reduce memory
+allocations and usage by deduplicating strings in memory, at the expense of slightly
+increased CPU usage.
+
+This will work effectively only for `string` fields being decoded have frequently
+the same value (e.g. if you have a string field that can only assume a small number
+of possible values).
+
+To enable string interning, add the `intern` keyword tag to your `json` tag on `string`
+fields, e.g.:
+
+```go
+type Foo struct {
+  UUID  string `json:"uuid"`         // will not be interned during unmarshaling
+  State string `json:"state,intern"` // will be interned during unmarshaling
+}
+```
+
 ## Issues, Notes, and Limitations
 
 * easyjson is still early in its development. As such, there are likely to be

--- a/benchmark/go.sum
+++ b/benchmark/go.sum
@@ -2,6 +2,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
+github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/json-iterator/go v1.1.7 h1:KfgG9LzI+pYjr4xvmz/5H4FXjokeP+rlHLhv3iH62Fo=
 github.com/json-iterator/go v1.1.7/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421 h1:ZqeYNhU3OHLH3mGKHDcjJRFFRrJa6eAM5H+CtDdOsPc=

--- a/gen/decoder.go
+++ b/gen/decoder.go
@@ -112,9 +112,15 @@ func (g *Generator) genTypeDecoderNoCheck(t reflect.Type, out string, tags field
 		fmt.Fprintln(g.out, ws+out+" = "+dec)
 		return nil
 	} else if dec := primitiveStringDecoders[t.Kind()]; dec != "" && tags.asString {
+		if tags.intern && t.Kind() == reflect.String {
+			dec = "in.StringIntern()"
+		}
 		fmt.Fprintln(g.out, ws+out+" = "+g.getType(t)+"("+dec+")")
 		return nil
 	} else if dec := primitiveDecoders[t.Kind()]; dec != "" {
+		if tags.intern && t.Kind() == reflect.String {
+			dec = "in.StringIntern()"
+		}
 		fmt.Fprintln(g.out, ws+out+" = "+g.getType(t)+"("+dec+")")
 		return nil
 	}
@@ -385,7 +391,6 @@ func getStructFields(t reflect.Type) ([]reflect.StructField, error) {
 			t1 = t1.Elem()
 		}
 
-
 		if t1.Kind() == reflect.Struct {
 			fs, err := getStructFields(t1)
 			if err != nil {
@@ -398,7 +403,6 @@ func getStructFields(t reflect.Type) ([]reflect.StructField, error) {
 			}
 		}
 	}
-
 
 	for i := 0; i < t.NumField(); i++ {
 		f := t.Field(i)

--- a/gen/encoder.go
+++ b/gen/encoder.go
@@ -58,6 +58,7 @@ type fieldTags struct {
 	noOmitEmpty bool
 	asString    bool
 	required    bool
+	intern      bool
 }
 
 // parseFieldTags parses the json field tag into a structure.
@@ -78,6 +79,8 @@ func parseFieldTags(f reflect.StructField) fieldTags {
 			ret.asString = true
 		case s == "required":
 			ret.required = true
+		case s == "intern":
+			ret.intern = true
 		}
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/mailru/easyjson
 
 go 1.12
+
+require github.com/josharian/intern v1.0.0

--- a/jlexer/lexer.go
+++ b/jlexer/lexer.go
@@ -14,6 +14,8 @@ import (
 	"unicode"
 	"unicode/utf16"
 	"unicode/utf8"
+
+	"github.com/josharian/intern"
 )
 
 // tokenKind determines type of a token.
@@ -641,6 +643,20 @@ func (r *Lexer) String() string {
 		return ""
 	}
 	ret := string(r.token.byteValue)
+	r.consume()
+	return ret
+}
+
+// StringIntern reads a string literal, and performs string interning on it.
+func (r *Lexer) StringIntern() string {
+	if r.token.kind == tokenUndef && r.Ok() {
+		r.FetchToken()
+	}
+	if !r.Ok() || r.token.kind != tokenString {
+		r.errInvalidToken("string")
+		return ""
+	}
+	ret := intern.Bytes(r.token.byteValue)
 	r.consume()
 	return ret
 }

--- a/tests/basic_test.go
+++ b/tests/basic_test.go
@@ -56,6 +56,7 @@ var testCases = []struct {
 	{&myGenDeclaredValue, myGenDeclaredString},
 	{&myGenDeclaredWithCommentValue, myGenDeclaredWithCommentString},
 	{&myTypeDeclaredValue, myTypeDeclaredString},
+	{&intern, internString},
 }
 
 func TestMarshal(t *testing.T) {

--- a/tests/intern.go
+++ b/tests/intern.go
@@ -1,0 +1,14 @@
+package tests
+
+//easyjson:json
+type NoIntern struct {
+	Field string `json:"field"`
+}
+
+//easyjson:json
+type Intern struct {
+	Field string `json:"field,intern"`
+}
+
+var intern = Intern{Field: "interned"}
+var internString = `{"field":"interned"}`

--- a/tests/intern_test.go
+++ b/tests/intern_test.go
@@ -1,0 +1,35 @@
+package tests
+
+import (
+	"testing"
+
+	"github.com/mailru/easyjson"
+)
+
+func TestStringIntern(t *testing.T) {
+	data := []byte(`{"field": "string interning test"}`)
+
+	var i Intern
+	allocsPerRun := testing.AllocsPerRun(1000, func() {
+		i = Intern{}
+		easyjson.Unmarshal(data, &i)
+		if i.Field != "string interning test" {
+			t.Fatalf("wrong value: %q", i.Field)
+		}
+	})
+	if allocsPerRun != 1 {
+		t.Fatalf("expected 1 allocs, got %f", allocsPerRun)
+	}
+
+	var n NoIntern
+	allocsPerRun = testing.AllocsPerRun(1000, func() {
+		n = NoIntern{}
+		easyjson.Unmarshal(data, &n)
+		if n.Field != "string interning test" {
+			t.Fatalf("wrong value: %q", n.Field)
+		}
+	})
+	if allocsPerRun != 2 {
+		t.Fatalf("expected 2 allocs, got %f", allocsPerRun)
+	}
+}


### PR DESCRIPTION
Uses [josharian/intern](https://github.com/josharian/intern) to optionally perform string interning during unmarshaling.
Saves one allocation per string field.

Fixes https://github.com/mailru/easyjson/issues/191