### PR TITLE
Added pragma easyjson:skip to exclude structs from generating stage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ generate: build
 		./tests/html.go \
 		./tests/unknown_fields.go \
 		./tests/type_declaration.go \
+		./tests/type_declaration_skip.go \
 		./tests/members_escaped.go \
 		./tests/members_unescaped.go \
 		./tests/intern.go \
@@ -43,6 +44,7 @@ generate: build
 	bin/easyjson -disallow_unknown_fields ./tests/disallow_unknown.go
 	bin/easyjson ./tests/unknown_fields.go
 	bin/easyjson ./tests/type_declaration.go
+	bin/easyjson -all ./tests/type_declaration_skip.go
 	bin/easyjson ./tests/members_escaped.go
 	bin/easyjson -disable_members_unescape ./tests/members_unescaped.go
 	bin/easyjson ./tests/intern.go

--- a/README.md
+++ b/README.md
@@ -62,7 +62,15 @@ Usage of easyjson:
 ```
 
 Using `-all` will generate marshalers/unmarshalers for all Go structs in the
-file. If `-all` is not provided, then only those structs whose preceding
+file excluding those structs whose preceding comment starts with `easyjson:skip`.
+For example: 
+
+```go
+//easyjson:skip
+type A struct {}
+```
+
+If `-all` is not provided, then only those structs whose preceding
 comment starts with `easyjson:json` will have marshalers/unmarshalers
 generated. For example:
 

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -26,16 +26,16 @@ type visitor struct {
 	name string
 }
 
-func (p *Parser) needType(comments string) bool {
+func (p *Parser) needType(comments string) (skip, explicit bool) {
 	for _, v := range strings.Split(comments, "\n") {
 		if strings.HasPrefix(v, structSkipComment) {
-			return false
+			return true, false
 		}
 		if strings.HasPrefix(v, structComment) {
-			return true
+			return false, true
 		}
 	}
-	return false
+	return false, false
 }
 
 func (v *visitor) Visit(n ast.Node) (w ast.Visitor) {
@@ -47,21 +47,23 @@ func (v *visitor) Visit(n ast.Node) (w ast.Visitor) {
 		return v
 
 	case *ast.GenDecl:
-		explicit := v.needType(n.Doc.Text())
-		if !explicit {
-			return v
-		}
+		skip, explicit := v.needType(n.Doc.Text())
 
-		for _, nc := range n.Specs {
-			switch nct := nc.(type) {
-			case *ast.TypeSpec:
-				nct.Doc = n.Doc
+		if skip || explicit {
+			for _, nc := range n.Specs {
+				switch nct := nc.(type) {
+				case *ast.TypeSpec:
+					nct.Doc = n.Doc
+				}
 			}
 		}
 
 		return v
 	case *ast.TypeSpec:
-		explicit := v.needType(n.Doc.Text())
+		skip, explicit := v.needType(n.Doc.Text())
+		if skip {
+			return nil
+		}
 		if !explicit && !v.AllStructs {
 			return nil
 		}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -8,7 +8,10 @@ import (
 	"strings"
 )
 
-const structComment = "easyjson:json"
+const (
+	structComment     = "easyjson:json"
+	structSkipComment = "easyjson:skip"
+)
 
 type Parser struct {
 	PkgPath     string
@@ -25,6 +28,9 @@ type visitor struct {
 
 func (p *Parser) needType(comments string) bool {
 	for _, v := range strings.Split(comments, "\n") {
+		if strings.HasPrefix(v, structSkipComment) {
+			return false
+		}
 		if strings.HasPrefix(v, structComment) {
 			return true
 		}

--- a/tests/basic_test.go
+++ b/tests/basic_test.go
@@ -57,6 +57,7 @@ var testCases = []struct {
 	{&myGenDeclaredValue, myGenDeclaredString},
 	{&myGenDeclaredWithCommentValue, myGenDeclaredWithCommentString},
 	{&myTypeDeclaredValue, myTypeDeclaredString},
+	{&myTypeNotSkippedValue, myTypeNotSkippedString},
 	{&intern, internString},
 }
 

--- a/tests/basic_test.go
+++ b/tests/basic_test.go
@@ -2,11 +2,10 @@ package tests
 
 import (
 	"bytes"
+	"encoding/json"
 	"net/http/httptest"
 	"reflect"
 	"testing"
-
-	"encoding/json"
 
 	"github.com/mailru/easyjson"
 	"github.com/mailru/easyjson/jwriter"
@@ -253,6 +252,7 @@ func TestDisallowUnknown(t *testing.T) {
 
 var testNotGeneratedTypeCases = []interface{}{
 	TypeNotDeclared{},
+	TypeSkipped{},
 }
 
 func TestMethodsNoGenerated(t *testing.T) {

--- a/tests/type_declaration.go
+++ b/tests/type_declaration.go
@@ -23,6 +23,11 @@ type (
 	}
 )
 
+//easyjson:skip
+type TypeSkipped struct {
+	Value string
+}
+
 var (
 	myGenDeclaredValue             = TypeDeclared{Value: "GenDeclared"}
 	myGenDeclaredString            = `{"Value":"GenDeclared"}`

--- a/tests/type_declaration.go
+++ b/tests/type_declaration.go
@@ -23,11 +23,6 @@ type (
 	}
 )
 
-//easyjson:skip
-type TypeSkipped struct {
-	Value string
-}
-
 var (
 	myGenDeclaredValue             = TypeDeclared{Value: "GenDeclared"}
 	myGenDeclaredString            = `{"Value":"GenDeclared"}`

--- a/tests/type_declaration_skip.go
+++ b/tests/type_declaration_skip.go
@@ -1,0 +1,15 @@
+package tests
+
+//easyjson:skip
+type TypeSkipped struct {
+	Value string
+}
+
+type TypeNotSkipped struct {
+	Value string
+}
+
+var (
+	myTypeNotSkippedValue  = TypeDeclared{Value: "TypeNotSkipped"}
+	myTypeNotSkippedString = `{"Value":"TypeNotSkipped"}`
+)


### PR DESCRIPTION
It allows manually control which structs should be skipped when using option `-all`.

Closes #288 