### PR TITLE
Added 2 fuzzers

### DIFF
--- a/jlexer/fuzz.go
+++ b/jlexer/fuzz.go
@@ -1,0 +1,7 @@
+package jlexer
+
+func Fuzz(data []byte) int {
+	l := Lexer{Data: data}
+	_ = l.UnsafeString()
+	return 1
+}

--- a/parser/fuzz.go
+++ b/parser/fuzz.go
@@ -1,0 +1,14 @@
+package parser
+
+import "flag"
+
+var allStructs = flag.Bool("all", false, "generate marshaler/unmarshalers for all structs in a file")
+
+func Fuzz(data []byte) int {
+	p := Parser{AllStructs: *allStructs}
+	err := p.Parse(string(data), false)
+	if err != nil {
+		return 0
+	}
+	return 1
+}


### PR DESCRIPTION
This PR adds 2 fuzzers. The fuzzers may be useful as [previous fuzzing efforts](https://github.com/mailru/easyjson/issues/72) of Easyjson have proven fruitful.

I suggest integrating Easyjson into OSS-fuzz to allow the fuzzers to be run continuosly. Integration would mean that Google runs the fuzzers on their platform and sends bug reports if any bugs are found. The service is free, but is offered with an implied expectation that bugs are fixed, so the efforts are put to good use.

I can confirm that the fuzzers run on OSS-fuzz's infrastructure, and I will be happy to integrate Easyjson. All I need are the email addresses for bug reports. These will be publicly available and can be changed anytime. It is my assumption that to setup continuous fuzzing through OSS-fuzz, we do need to provide references to adopters/users, so any such information will improve the chances of Google accepting the application of Easyjson.

Also, it will be my pleasure to add more fuzzers. Especially the rest of the jlexer package should be quickly covered. I am uploading these two for now to hear your kind feedback.