### PR TITLE
Remove spurious print

### DIFF
--- a/gen/decoder.go
+++ b/gen/decoder.go
@@ -299,7 +299,6 @@ func (g *Generator) genTypeDecoderNoCheck(t reflect.Type, out string, tags field
 		fmt.Fprintln(g.out, ws+"}")
 
 	case reflect.Interface:
-		fmt.Printf("//%v: %v", out, g.interfaceIsEasyjsonUnmarshaller(t))
 		if t.NumMethod() != 0 {
 			if g.interfaceIsEasyjsonUnmarshaller(t) {
 				fmt.Fprintln(g.out, ws+out+".UnmarshalEasyJSON(in)")


### PR DESCRIPTION
#202 introduced a spurious print to the code generator. It doesn't break things as-is because it appears to print before the rest of the code (so it only adds to the first line, which is already the "DO NOT EDIT" header).