### PR TITLE
jlexer skipped json value validation added

### DIFF
--- a/jlexer/lexer.go
+++ b/jlexer/lexer.go
@@ -528,6 +528,7 @@ func (r *Lexer) Skip() {
 func (r *Lexer) SkipRecursive() {
 	r.scanToken()
 	var start, end byte
+	startPos := r.start
 
 	switch r.token.delimValue {
 	case '{':
@@ -553,6 +554,14 @@ func (r *Lexer) SkipRecursive() {
 			level--
 			if level == 0 {
 				r.pos += i + 1
+				if !json.Valid(r.Data[startPos:r.pos]) {
+					r.pos = len(r.Data)
+					r.fatalError = &LexerError{
+						Reason: "skipped array/object json value is invalid",
+						Offset: r.pos,
+						Data:   string(r.Data[r.pos:]),
+					}
+				}
 				return
 			}
 		case c == '\\' && inQuotes:

--- a/jlexer/lexer_test.go
+++ b/jlexer/lexer_test.go
@@ -201,6 +201,10 @@ func TestSkipRecursive(t *testing.T) {
 
 		// object with double slashes at the end of string
 		{toParse: `{"a":"hey\\"}, 4`, left: ", 4"},
+
+		// make sure skipping an invalid json results in an error
+		{toParse: `{"a": [ ##invalid json## ]}, 4`, wantError: true},
+		{toParse: `{"a": [ [1], [ ##invalid json## ]]}, 4`, wantError: true},
 	} {
 		l := Lexer{Data: []byte(test.toParse)}
 


### PR DESCRIPTION
Hey there. Very interesting project! Here a suggestion 
Since json data is not validated for skipped data when calling Unmarshal on the struct directly. This poses in my opinion a security risk

```
{"x": [ ### something unverified like an image or a link or what ever # ]}
```
json data like the one above could pass unverified in the system ...
What do you think?
BTW the benchmarks on my system don't change with this change.
Best Michael
