### PR TITLE
added power support arch ppc64le on yml file.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+arch:
+  - amd64
+  - ppc64le
 language: go
 
 go:
@@ -7,10 +10,5 @@ go:
 matrix:
   allow_failures:
     - go: tip
-    # added power support arch.
-  allow_failures:
-    - go: tip
-  arch:
-    - ppc64le
 install:
   - go get golang.org/x/lint/golint

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ go:
 matrix:
   allow_failures:
     - go: tip
-
+    # added power support arch.
+  allow_failures:
+    - go: tip
+      arch: - ppc64le
 install:
   - go get golang.org/x/lint/golint

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ matrix:
     # added power support arch.
   allow_failures:
     - go: tip
-      arch: - ppc64le
+  arch:
+    - ppc64le
 install:
   - go get golang.org/x/lint/golint


### PR DESCRIPTION
Added power support for the travis.yml file with ppc64le. This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing. For more info tag @gerrith3.

