### PR TITLE
Unmarshalling fails if base64-encoded string contains forward slash

### DIFF
--- a/jlexer/lexer.go
+++ b/jlexer/lexer.go
@@ -712,6 +712,10 @@ func (r *Lexer) Bytes() []byte {
 		r.errInvalidToken("string")
 		return nil
 	}
+	if err := r.unescapeStringToken(); err != nil {
+		r.errInvalidToken("string")
+		return nil
+	}
 	ret := make([]byte, base64.StdEncoding.DecodedLen(len(r.token.byteValue)))
 	n, err := base64.StdEncoding.Decode(ret, r.token.byteValue)
 	if err != nil {

--- a/jlexer/lexer_test.go
+++ b/jlexer/lexer_test.go
@@ -89,6 +89,7 @@ func TestBytes(t *testing.T) {
 	}{
 		{toParse: `"c2ltcGxlIHN0cmluZw=="`, want: "simple string"},
 		{toParse: " \r\r\n\t  " + `"dGVzdA=="`, want: "test"},
+		{toParse: `"c3ViamVjdHM\/X2Q9MQ=="`, want: "subjects?_d=1"}, // base64 with forward slash escaped
 
 		{toParse: `5`, wantError: true},                     // not a JSON string
 		{toParse: `"foobar"`, wantError: true},              // not base64 encoded


### PR DESCRIPTION
Fixed lexer in decoding base64-encoded []byte field with forward slash in it.