### PR TITLE
Nil slice as empty

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ tiny-test: tiny-generate
 	go test -v -tags easyjson_nounsafe ./tiny-tests
 	@ golint -set_exit_status ./tiny-tests/*_easyjson.go
 	@ echo "No files should be listed below:"
-	@ grep -l encoding/json ./tiny-tests/*.go
+	@ grep -l encoding/json ./tiny-tests/*.go || true
 
 bench-other: generate
 	cd benchmark && make

--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ test: generate
 	golint -set_exit_status ./tests/*_easyjson.go
 
 tiny-generate: build
-	bin/easyjson -all \
+	bin/easyjson -all -snake_case \
 		./tiny-tests/cosmwasm.go
 
 tiny-test: tiny-generate

--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,9 @@ tiny-generate: build
 tiny-test: tiny-generate
 	# look into nounsafe later, this uses reflect, so I remove it just in case
 	go test -v -tags easyjson_nounsafe ./tiny-tests
-	golint -set_exit_status ./tiny-tests/*_easyjson.go
+	@ golint -set_exit_status ./tiny-tests/*_easyjson.go
+	@ echo "No files should be listed below:"
+	@ grep -l encoding/json ./tiny-tests/*.go
 
 bench-other: generate
 	cd benchmark && make

--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,14 @@ test: generate
 	cd benchmark && go test -benchmem -tags use_easyjson -bench .
 	golint -set_exit_status ./tests/*_easyjson.go
 
+tiny-generate: build
+	bin/easyjson -all \
+		./tiny-tests/cosmwasm.go
+
+tiny-test: tiny-generate
+	go test ./tiny-tests
+	# golint -set_exit_status ./tiny-tests/*_easyjson.go
+
 bench-other: generate
 	cd benchmark && make
 

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ clean:
 	rm -rf benchmark/*_easyjson.go
 
 build:
-	go build -i -o ./bin/easyjson ./easyjson
+	go build -o ./bin/easyjson ./easyjson
 
 generate: build
 	bin/easyjson -stubs \
@@ -67,7 +67,7 @@ tiny-generate: build
 		./tiny-tests/cosmwasm.go
 
 tiny-test: tiny-generate
-	go test ./tiny-tests
+	go test -v ./tiny-tests
 	# golint -set_exit_status ./tiny-tests/*_easyjson.go
 
 bench-other: generate

--- a/Makefile
+++ b/Makefile
@@ -67,8 +67,9 @@ tiny-generate: build
 		./tiny-tests/cosmwasm.go
 
 tiny-test: tiny-generate
-	go test -v ./tiny-tests
-	# golint -set_exit_status ./tiny-tests/*_easyjson.go
+	# look into nounsafe later, this uses reflect, so I remove it just in case
+	go test -v -tags easyjson_nounsafe ./tiny-tests
+	golint -set_exit_status ./tiny-tests/*_easyjson.go
 
 bench-other: generate
 	cd benchmark && make

--- a/gen/decoder.go
+++ b/gen/decoder.go
@@ -306,6 +306,9 @@ func (g *Generator) genTypeDecoderNoCheck(t reflect.Type, out string, tags field
 				return fmt.Errorf("interface type %v not supported: only interface{} and easyjson/json Unmarshaler are allowed", t)
 			}
 		} else {
+			// we enable this only when needed
+			g.imports["encoding/json"] = "json"
+
 			fmt.Fprintln(g.out, ws+"if m, ok := "+out+".(easyjson.Unmarshaler); ok {")
 			fmt.Fprintln(g.out, ws+"m.UnmarshalEasyJSON(in)")
 			fmt.Fprintln(g.out, ws+"} else if m, ok := "+out+".(json.Unmarshaler); ok {")

--- a/gen/decoder.go
+++ b/gen/decoder.go
@@ -53,9 +53,7 @@ var primitiveStringDecoders = map[reflect.Kind]string{
 	reflect.Float64: "in.Float64Str()",
 }
 
-var customDecoders = map[string]string{
-	"json.Number": "in.JsonNumber()",
-}
+var customDecoders = map[string]string{}
 
 // genTypeDecoder generates decoding code for the type t, but uses unmarshaler interface if implemented by t.
 func (g *Generator) genTypeDecoder(t reflect.Type, out string, tags fieldTags, indent int) error {

--- a/gen/encoder.go
+++ b/gen/encoder.go
@@ -53,13 +53,14 @@ var primitiveStringEncoders = map[reflect.Kind]string{
 type fieldTags struct {
 	name string
 
-	omit        bool
-	omitEmpty   bool
-	noOmitEmpty bool
-	asString    bool
-	required    bool
-	intern      bool
-	noCopy      bool
+	omit            bool
+	omitEmpty       bool
+	noOmitEmpty     bool
+	asString        bool
+	required        bool
+	intern          bool
+	noCopy          bool
+	nilSliceAsEmpty bool
 }
 
 // parseFieldTags parses the json field tag into a structure.
@@ -84,6 +85,8 @@ func parseFieldTags(f reflect.StructField) fieldTags {
 			ret.intern = true
 		case s == "nocopy":
 			ret.noCopy = true
+		case s == "emptyslice":
+			ret.nilSliceAsEmpty = true
 		}
 	}
 
@@ -152,7 +155,7 @@ func (g *Generator) genTypeEncoderNoCheck(t reflect.Type, in string, tags fieldT
 				fmt.Fprintln(g.out, ws+"out.Base64Bytes("+in+")")
 			}
 		} else {
-			if !assumeNonEmpty {
+			if !assumeNonEmpty && !tags.nilSliceAsEmpty {
 				fmt.Fprintln(g.out, ws+"if "+in+" == nil && (out.Flags & jwriter.NilSliceAsEmpty) == 0 {")
 				fmt.Fprintln(g.out, ws+`  out.RawString("null")`)
 				fmt.Fprintln(g.out, ws+"} else {")

--- a/gen/generator.go
+++ b/gen/generator.go
@@ -61,10 +61,9 @@ type Generator struct {
 func NewGenerator(filename string) *Generator {
 	ret := &Generator{
 		imports: map[string]string{
-			pkgWriter:       "jwriter",
-			pkgLexer:        "jlexer",
-			pkgEasyJSON:     "easyjson",
-			"encoding/json": "json",
+			pkgWriter:   "jwriter",
+			pkgLexer:    "jlexer",
+			pkgEasyJSON: "easyjson",
 		},
 		fieldNamer:    DefaultFieldNamer{},
 		marshalers:    make(map[reflect.Type]bool),
@@ -186,7 +185,6 @@ func (g *Generator) printHeader() {
 	fmt.Println("")
 	fmt.Println("// suppress unused package warning")
 	fmt.Println("var (")
-	fmt.Println("   _ *json.RawMessage")
 	fmt.Println("   _ *jlexer.Lexer")
 	fmt.Println("   _ *jwriter.Writer")
 	fmt.Println("   _ easyjson.Marshaler")

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/mailru/easyjson
 
-go 1.12
+go 1.16
 
 require github.com/josharian/intern v1.0.0

--- a/jlexer/lexer.go
+++ b/jlexer/lexer.go
@@ -1148,31 +1148,6 @@ func (r *Lexer) GetNonFatalErrors() []*LexerError {
 	return r.multipleErrors
 }
 
-// JsonNumber fetches and json.Number from 'encoding/json' package.
-// Both int, float or string, contains them are valid values
-func (r *Lexer) JsonNumber() json.Number {
-	if r.token.kind == tokenUndef && r.Ok() {
-		r.FetchToken()
-	}
-	if !r.Ok() {
-		r.errInvalidToken("json.Number")
-		return json.Number("")
-	}
-
-	switch r.token.kind {
-	case tokenString:
-		return json.Number(r.String())
-	case tokenNumber:
-		return json.Number(r.Raw())
-	case tokenNull:
-		r.Null()
-		return json.Number("")
-	default:
-		r.errSyntax()
-		return json.Number("")
-	}
-}
-
 // Interface fetches an interface{} analogous to the 'encoding/json' package.
 func (r *Lexer) Interface() interface{} {
 	if r.token.kind == tokenUndef && r.Ok() {

--- a/jlexer/lexer_test.go
+++ b/jlexer/lexer_test.go
@@ -2,7 +2,6 @@ package jlexer
 
 import (
 	"bytes"
-	"encoding/json"
 	"reflect"
 	"testing"
 )
@@ -289,68 +288,6 @@ func TestConsumed(t *testing.T) {
 			t.Errorf("[%d, %q] Consumed() error: %v", i, test.toParse, err)
 		} else if err == nil && test.wantError {
 			t.Errorf("[%d, %q] Consumed() ok; want error", i, test.toParse)
-		}
-	}
-}
-
-func TestJsonNumber(t *testing.T) {
-	for i, test := range []struct {
-		toParse        string
-		want           json.Number
-		wantLexerError bool
-		wantValue      interface{}
-		wantValueError bool
-	}{
-		{toParse: `10`, want: json.Number("10"), wantValue: int64(10)},
-		{toParse: `0`, want: json.Number("0"), wantValue: int64(0)},
-		{toParse: `0.12`, want: json.Number("0.12"), wantValue: 0.12},
-		{toParse: `25E-4`, want: json.Number("25E-4"), wantValue: 25e-4},
-
-		{toParse: `"10"`, want: json.Number("10"), wantValue: int64(10)},
-		{toParse: `"0"`, want: json.Number("0"), wantValue: int64(0)},
-		{toParse: `"0.12"`, want: json.Number("0.12"), wantValue: 0.12},
-		{toParse: `"25E-4"`, want: json.Number("25E-4"), wantValue: 25e-4},
-
-		{toParse: `"foo"`, want: json.Number("foo"), wantValueError: true},
-		{toParse: `null`, want: json.Number(""), wantValueError: true},
-
-		{toParse: `"a""`, want: json.Number("a"), wantValueError: true},
-
-		{toParse: `[1]`, want: json.Number(""), wantLexerError: true, wantValueError: true},
-		{toParse: `{}`, want: json.Number(""), wantLexerError: true, wantValueError: true},
-		{toParse: `a`, want: json.Number(""), wantLexerError: true, wantValueError: true},
-	} {
-		l := Lexer{Data: []byte(test.toParse)}
-
-		got := l.JsonNumber()
-		if got != test.want {
-			t.Errorf("[%d, %q] JsonNumber() = %v; want %v", i, test.toParse, got, test.want)
-		}
-
-		err := l.Error()
-		if err != nil && !test.wantLexerError {
-			t.Errorf("[%d, %q] JsonNumber() lexer error: %v", i, test.toParse, err)
-		} else if err == nil && test.wantLexerError {
-			t.Errorf("[%d, %q] JsonNumber() ok; want lexer error", i, test.toParse)
-		}
-
-		var valueErr error
-		var gotValue interface{}
-		switch test.wantValue.(type) {
-		case float64:
-			gotValue, valueErr = got.Float64()
-		default:
-			gotValue, valueErr = got.Int64()
-		}
-
-		if !reflect.DeepEqual(gotValue, test.wantValue) && !test.wantLexerError && !test.wantValueError {
-			t.Errorf("[%d, %q] JsonNumber() = %v; want %v", i, test.toParse, gotValue, test.wantValue)
-		}
-
-		if valueErr != nil && !test.wantValueError {
-			t.Errorf("[%d, %q] JsonNumber() value error: %v", i, test.toParse, valueErr)
-		} else if valueErr == nil && test.wantValueError {
-			t.Errorf("[%d, %q] JsonNumber() ok; want value error", i, test.toParse)
 		}
 	}
 }

--- a/tests/intern_test.go
+++ b/tests/intern_test.go
@@ -20,8 +20,8 @@ func TestStringIntern(t *testing.T) {
 			t.Fatalf("wrong value: %q", i.Field)
 		}
 	})
-	if allocsPerRun != 1 {
-		t.Fatalf("expected 1 allocs, got %f", allocsPerRun)
+	if allocsPerRun != 0 {
+		t.Fatalf("expected 0 allocs, got %f", allocsPerRun)
 	}
 
 	var n NoIntern
@@ -35,7 +35,7 @@ func TestStringIntern(t *testing.T) {
 			t.Fatalf("wrong value: %q", n.Field)
 		}
 	})
-	if allocsPerRun != 2 {
-		t.Fatalf("expected 2 allocs, got %f", allocsPerRun)
+	if allocsPerRun != 1 {
+		t.Fatalf("expected 1 allocs, got %f", allocsPerRun)
 	}
 }

--- a/tests/nocopy_test.go
+++ b/tests/nocopy_test.go
@@ -53,8 +53,8 @@ func TestNocopy(t *testing.T) {
 			t.Fatalf("wrong value: %q", res.B)
 		}
 	})
-	if allocsPerRun != 1 {
-		t.Fatalf("noCopy field unmarshal: expected 1 allocs, got %f", allocsPerRun)
+	if allocsPerRun != 0 {
+		t.Fatalf("noCopy field unmarshal: expected 0 allocs, got %f", allocsPerRun)
 	}
 
 	data = []byte(`{"a": "valueNoCopy"}`)
@@ -67,7 +67,7 @@ func TestNocopy(t *testing.T) {
 			t.Fatalf("wrong value: %q", res.A)
 		}
 	})
-	if allocsPerRun != 2 {
-		t.Fatalf("copy field unmarshal: expected 2 allocs, got %f", allocsPerRun)
+	if allocsPerRun != 1 {
+		t.Fatalf("copy field unmarshal: expected 1 allocs, got %f", allocsPerRun)
 	}
 }

--- a/tiny-tests/cosmwasm.go
+++ b/tiny-tests/cosmwasm.go
@@ -1,0 +1,47 @@
+package tinytest
+
+// TODO: investigate nocopy optimizations
+
+// basic, standard struct (with embedded structs)
+type Env struct {
+	Block    BlockInfo    `json:"block"`
+	Contract ContractInfo `json:"contract"`
+}
+
+type BlockInfo struct {
+	Height int64 `json:"height"`
+	Time   int64 `json:"time,string"`
+}
+
+type ContractInfo struct {
+	Address string `json:"address"`
+}
+
+// another important struct that includes a slice of structs (which caused issues with another parser)
+type MessageInfo struct {
+	Signer string `json:"signer"`
+	// TODO: how to ensure empty funds -> [] not nil
+	Funds []Coin `json:"funds"`
+}
+
+type Coin struct {
+	Denom  string `json:"denom"`
+	Amount string `json:"amount"`
+}
+
+// emulate Rust enum, only one should ever be set
+type ExecuteMsg struct {
+	Deposit  *DepositMsg  `json:"deposit,omitempty"`
+	Withdraw *WithdrawMsg `json:"withdraw,omitempty"`
+}
+
+type DepositMsg struct {
+	ToAccount string `json:"to_account"`
+	Amount    string `json:"amount"`
+}
+
+// withdraws all funds
+type WithdrawMsg struct {
+	// use a different field here to ensure we have proper types (json must not overlap)
+	FromAccount string `json:"from_account"`
+}

--- a/tiny-tests/cosmwasm.go
+++ b/tiny-tests/cosmwasm.go
@@ -24,6 +24,29 @@ type MessageInfo struct {
 	Funds []Coin
 }
 
+type Coin struct {
+	Denom  string
+	Amount string
+}
+
+// emulate Rust enum, only one should ever be set
+type ExecuteMsg struct {
+	Deposit  *DepositMsg  `json:",omitempty"`
+	Withdraw *WithdrawMsg `json:",omitempty"`
+}
+type DepositMsg struct {
+	ToAccount string
+	Amount    string
+}
+
+// withdraws all funds
+type WithdrawMsg struct {
+	// use a different field here to ensure we have proper types (json must not overlap)
+	FromAccount string
+}
+
+/**** Test Helpers ****/
+
 // For Testing
 func (a *MessageInfo) Equals(b *MessageInfo) bool {
 	if a.Signer != b.Signer {
@@ -39,17 +62,6 @@ func (a *MessageInfo) Equals(b *MessageInfo) bool {
 		}
 	}
 	return true
-}
-
-type Coin struct {
-	Denom  string
-	Amount string
-}
-
-// emulate Rust enum, only one should ever be set
-type ExecuteMsg struct {
-	Deposit  *DepositMsg  `json:",omitempty"`
-	Withdraw *WithdrawMsg `json:",omitempty"`
 }
 
 // For Testing
@@ -79,15 +91,4 @@ func (a *ExecuteMsg) Equals(b *ExecuteMsg) bool {
 	}
 
 	return true
-}
-
-type DepositMsg struct {
-	ToAccount string
-	Amount    string
-}
-
-// withdraws all funds
-type WithdrawMsg struct {
-	// use a different field here to ensure we have proper types (json must not overlap)
-	FromAccount string
 }

--- a/tiny-tests/cosmwasm.go
+++ b/tiny-tests/cosmwasm.go
@@ -24,6 +24,23 @@ type MessageInfo struct {
 	Funds []Coin
 }
 
+// For Testing
+func (a *MessageInfo) Equals(b *MessageInfo) bool {
+	if a.Signer != b.Signer {
+		return false
+	}
+	if len(a.Funds) != len(b.Funds) {
+		return false
+	}
+	for i, af := range a.Funds {
+		bf := b.Funds[i]
+		if af != bf {
+			return false
+		}
+	}
+	return true
+}
+
 type Coin struct {
 	Denom  string
 	Amount string
@@ -33,6 +50,35 @@ type Coin struct {
 type ExecuteMsg struct {
 	Deposit  *DepositMsg  `json:",omitempty"`
 	Withdraw *WithdrawMsg `json:",omitempty"`
+}
+
+// For Testing
+func (a *ExecuteMsg) Equals(b *ExecuteMsg) bool {
+	if a.Deposit == nil && b.Deposit != nil {
+		return false
+	}
+	if a.Deposit != nil {
+		if b.Deposit == nil {
+			return false
+		}
+		if *a.Deposit != *b.Deposit {
+			return false
+		}
+	}
+
+	if a.Withdraw == nil && b.Withdraw != nil {
+		return false
+	}
+	if a.Withdraw != nil {
+		if b.Withdraw == nil {
+			return false
+		}
+		if *a.Withdraw != *b.Withdraw {
+			return false
+		}
+	}
+
+	return true
 }
 
 type DepositMsg struct {

--- a/tiny-tests/cosmwasm.go
+++ b/tiny-tests/cosmwasm.go
@@ -4,44 +4,44 @@ package tinytest
 
 // basic, standard struct (with embedded structs)
 type Env struct {
-	Block    BlockInfo    `json:"block"`
-	Contract ContractInfo `json:"contract"`
+	Block    BlockInfo
+	Contract ContractInfo
 }
 
 type BlockInfo struct {
-	Height int64 `json:"height"`
-	Time   int64 `json:"time,string"`
+	Height int64
+	Time   int64 `json:",string"`
 }
 
 type ContractInfo struct {
-	Address string `json:"address"`
+	Address string
 }
 
 // another important struct that includes a slice of structs (which caused issues with another parser)
 type MessageInfo struct {
-	Signer string `json:"signer"`
+	Signer string
 	// TODO: how to ensure empty funds -> [] not nil
-	Funds []Coin `json:"funds"`
+	Funds []Coin
 }
 
 type Coin struct {
-	Denom  string `json:"denom"`
-	Amount string `json:"amount"`
+	Denom  string
+	Amount string
 }
 
 // emulate Rust enum, only one should ever be set
 type ExecuteMsg struct {
-	Deposit  *DepositMsg  `json:"deposit,omitempty"`
-	Withdraw *WithdrawMsg `json:"withdraw,omitempty"`
+	Deposit  *DepositMsg  `json:",omitempty"`
+	Withdraw *WithdrawMsg `json:",omitempty"`
 }
 
 type DepositMsg struct {
-	ToAccount string `json:"to_account"`
-	Amount    string `json:"amount"`
+	ToAccount string
+	Amount    string
 }
 
 // withdraws all funds
 type WithdrawMsg struct {
 	// use a different field here to ensure we have proper types (json must not overlap)
-	FromAccount string `json:"from_account"`
+	FromAccount string
 }

--- a/tiny-tests/cosmwasm.go
+++ b/tiny-tests/cosmwasm.go
@@ -20,8 +20,8 @@ type ContractInfo struct {
 // another important struct that includes a slice of structs (which caused issues with another parser)
 type MessageInfo struct {
 	Signer string
-	// TODO: how to ensure empty funds -> [] not nil
-	Funds []Coin
+	// Note: added custom tag "emptyslice" to never encode to nil, but rather []
+	Funds []Coin `json:",emptyslice"`
 }
 
 type Coin struct {

--- a/tiny-tests/cosmwasm_test.go
+++ b/tiny-tests/cosmwasm_test.go
@@ -59,7 +59,11 @@ func TestInfoEncoding(t *testing.T) {
 		"empty": {
 			input:    `{}`,
 			expected: MessageInfo{},
-			output:   `{"signer":"","funds":null}`,
+			// TODO: where to set this?
+			// desired behavior can be set by
+			// writer := &jwriter.Writer{Flags: jwriter.NilSliceAsEmpty}
+			// output: `{"signer":"","funds":[]}`,
+			output: `{"signer":"","funds":null}`,
 		},
 		"top fields": {
 			input: `{"signer":"cosmos1234","funds":[]}`,

--- a/tiny-tests/cosmwasm_test.go
+++ b/tiny-tests/cosmwasm_test.go
@@ -59,11 +59,7 @@ func TestInfoEncoding(t *testing.T) {
 		"empty": {
 			input:    `{}`,
 			expected: MessageInfo{},
-			// TODO: where to set this?
-			// desired behavior can be set by
-			// writer := &jwriter.Writer{Flags: jwriter.NilSliceAsEmpty}
-			// output: `{"signer":"","funds":[]}`,
-			output: `{"signer":"","funds":null}`,
+			output:   `{"signer":"","funds":[]}`,
 		},
 		"top fields": {
 			input: `{"signer":"cosmos1234","funds":[]}`,

--- a/tiny-tests/cosmwasm_test.go
+++ b/tiny-tests/cosmwasm_test.go
@@ -1,0 +1,53 @@
+package tinytest
+
+import (
+	"testing"
+)
+
+// Encode and decode types
+func TestEnvEncoding(t *testing.T) {
+	cases := map[string]struct {
+		input    string
+		expected Env
+	}{
+		"empty": {
+			input:    `{"contract":{}}`,
+			expected: Env{},
+		},
+		"full": {
+			input: `{"contract":{"address":"my-contract"},"block":{"time":"1234567890","height":42}}`,
+			expected: Env{
+				Contract: ContractInfo{Address: "my-contract"},
+				Block:    BlockInfo{Time: 1234567890, Height: 42},
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			// check it matches expectations
+			var loaded Env
+			err := loaded.UnmarshalJSON([]byte(tc.input))
+			if err != nil {
+				t.Fatalf("Unmarshaling: %s", err)
+			}
+			if loaded != tc.expected {
+				t.Fatalf("Unmarshaled doesn't match expected.\nGot %#v\nWanted %#v", loaded, tc.expected)
+			}
+
+			// check it matches itself
+			bz, err := loaded.MarshalJSON()
+			if err != nil {
+				t.Fatalf("Marshalling: %s", err)
+			}
+			var reloaded Env
+			err = reloaded.UnmarshalJSON(bz)
+			if err != nil {
+				t.Fatalf("Unmarshaling: %s", err)
+			}
+			if reloaded != loaded {
+				t.Fatalf("Full cycle changes data.\nHad %#v\nGot %#v", loaded, reloaded)
+			}
+		})
+	}
+}

--- a/tiny-tests/cosmwasm_test.go
+++ b/tiny-tests/cosmwasm_test.go
@@ -9,10 +9,12 @@ func TestEnvEncoding(t *testing.T) {
 	cases := map[string]struct {
 		input    string
 		expected Env
+		output   string
 	}{
 		"empty": {
 			input:    `{"contract":{}}`,
 			expected: Env{},
+			output:   `{"block":{"height":0,"time":"0"},"contract":{"address":""}}`,
 		},
 		"full": {
 			input: `{"contract":{"address":"my-contract"},"block":{"time":"1234567890","height":42}}`,
@@ -20,6 +22,7 @@ func TestEnvEncoding(t *testing.T) {
 				Contract: ContractInfo{Address: "my-contract"},
 				Block:    BlockInfo{Time: 1234567890, Height: 42},
 			},
+			output: `{"block":{"height":42,"time":"1234567890"},"contract":{"address":"my-contract"}}`,
 		},
 	}
 
@@ -35,18 +38,114 @@ func TestEnvEncoding(t *testing.T) {
 				t.Fatalf("Unmarshaled doesn't match expected.\nGot %#v\nWanted %#v", loaded, tc.expected)
 			}
 
+			// check proper output
+			bz, err := loaded.MarshalJSON()
+			if err != nil {
+				t.Fatalf("Marshalling: %s", err)
+			}
+			if string(bz) != tc.output {
+				t.Fatalf("Unexpected output: '%s'", string(bz))
+			}
+		})
+	}
+}
+
+func TestInfoEncoding(t *testing.T) {
+	cases := map[string]struct {
+		input    string
+		expected MessageInfo
+		output   string
+	}{
+		"empty": {
+			input:    `{}`,
+			expected: MessageInfo{},
+			output:   `{"signer":"","funds":null}`,
+		},
+		"top fields": {
+			input: `{"signer":"cosmos1234","funds":[]}`,
+			expected: MessageInfo{
+				Signer: "cosmos1234",
+				Funds:  []Coin{},
+			},
+			output: `{"signer":"cosmos1234","funds":[]}`,
+		},
+		"multiple coins": {
+			input: `{"signer":"cosmos1234","funds":[{"amount":"12345","denom":"uatom"},{"amount":"76543","denom":"utgd"}]}`,
+			expected: MessageInfo{
+				Signer: "cosmos1234",
+				Funds: []Coin{{
+					Amount: "12345",
+					Denom:  "uatom",
+				}, {
+					Amount: "76543",
+					Denom:  "utgd",
+				}},
+			},
+			output: `{"signer":"cosmos1234","funds":[{"denom":"uatom","amount":"12345"},{"denom":"utgd","amount":"76543"}]}`,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			// check it matches expectations
+			var loaded MessageInfo
+			err := loaded.UnmarshalJSON([]byte(tc.input))
+			if err != nil {
+				t.Fatalf("Unmarshaling: %s", err)
+			}
+			if !loaded.Equals(&tc.expected) {
+				t.Fatalf("Unmarshaled doesn't match expected.\nGot %#v\nWanted %#v", loaded, tc.expected)
+			}
+
 			// check it matches itself
 			bz, err := loaded.MarshalJSON()
 			if err != nil {
 				t.Fatalf("Marshalling: %s", err)
 			}
-			var reloaded Env
-			err = reloaded.UnmarshalJSON(bz)
+			if string(bz) != tc.output {
+				t.Fatalf("Unexpected output: '%s'", string(bz))
+			}
+		})
+	}
+}
+
+func TestMessageEncoding(t *testing.T) {
+	cases := map[string]struct {
+		input    string
+		expected ExecuteMsg
+		output   string
+	}{
+		"deposit": {
+			input:    `{"deposit":{"to_account":"cosmos1234567","amount":"1865"}}`,
+			expected: ExecuteMsg{Deposit: &DepositMsg{ToAccount: "cosmos1234567", Amount: "1865"}},
+			output:   `{"deposit":{"to_account":"cosmos1234567","amount":"1865"}}`,
+		},
+		"withdraw": {
+			input:    `{"withdraw":{"from_account":"wasm1542"}}`,
+			expected: ExecuteMsg{Withdraw: &WithdrawMsg{FromAccount: "wasm1542"}},
+			output:   `{"withdraw":{"from_account":"wasm1542"}}`,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			// check it matches expectations
+			var loaded ExecuteMsg
+			err := loaded.UnmarshalJSON([]byte(tc.input))
 			if err != nil {
 				t.Fatalf("Unmarshaling: %s", err)
 			}
-			if reloaded != loaded {
-				t.Fatalf("Full cycle changes data.\nHad %#v\nGot %#v", loaded, reloaded)
+			if !loaded.Equals(&tc.expected) {
+				t.Fatalf("Unmarshaled doesn't match expected.\nGot %#v\nWanted %#v", loaded, tc.expected)
+			}
+
+			// check it matches itself
+			bz, err := loaded.MarshalJSON()
+			if err != nil {
+				t.Fatalf("Marshalling: %s", err)
+			}
+			if string(bz) != tc.output {
+				t.Fatalf("Unexpected output: '%s'", string(bz))
 			}
 		})
 	}


### PR DESCRIPTION
Merge after #2 

Add a new json tag, `emptyslice` that can be applied to any `[]Xyz` field. If that field has length 0, rather than marshalling as `null`, it will marshal as `[]`. This is more inline with what the Rust encoder expects.