### PR TITLE
feat: add float_format flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,7 @@ generate: build
 	bin/easyjson -build_tags=use_easyjson -disable_members_unescape ./benchmark/data.go
 	bin/easyjson -disallow_unknown_fields ./tests/disallow_unknown.go
 	bin/easyjson -disable_members_unescape ./tests/members_unescaped.go
+	bin/easyjson -float_format='f' ./tests/float_format.go
 
 test: generate
 	go test \

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -36,6 +36,7 @@ type Generator struct {
 	OutName       string
 	BuildTags     string
 	GenBuildFlags string
+	FloatFmt      string
 
 	StubsOnly   bool
 	LeaveTemps  bool
@@ -115,6 +116,9 @@ func (g *Generator) writeMain() (path string, err error) {
 	fmt.Fprintf(f, "  g.SetPkg(%q, %q)\n", g.PkgName, g.PkgPath)
 	if g.BuildTags != "" {
 		fmt.Fprintf(f, "  g.SetBuildTags(%q)\n", g.BuildTags)
+	}
+	if g.FloatFmt != "" {
+		fmt.Fprintf(f, "  g.SetFloatFmt(%q)\n", g.FloatFmt)
 	}
 	if g.SnakeCase {
 		fmt.Fprintln(f, "  g.UseSnakeCase()")

--- a/easyjson/main.go
+++ b/easyjson/main.go
@@ -18,6 +18,7 @@ import (
 
 var buildTags = flag.String("build_tags", "", "build tags to add to generated file")
 var genBuildFlags = flag.String("gen_build_flags", "", "build flags when running the generator while bootstrapping")
+var floatFmt = flag.String("float_format", "", "float format to be used in json writer")
 var snakeCase = flag.Bool("snake_case", false, "use snake_case names instead of CamelCase by default")
 var lowerCamelCase = flag.Bool("lower_camel_case", false, "use lowerCamelCase names instead of CamelCase by default")
 var noStdMarshalers = flag.Bool("no_std_marshalers", false, "don't generate MarshalJSON/UnmarshalJSON funcs")
@@ -68,6 +69,11 @@ func generate(fname string) (err error) {
 		trimmedGenBuildFlags = strings.TrimSpace(*genBuildFlags)
 	}
 
+	var trimmedFloatFmt string
+	if *floatFmt != "" {
+		trimmedFloatFmt = strings.TrimSpace(*floatFmt)
+	}
+
 	g := bootstrap.Generator{
 		BuildTags:                trimmedBuildTags,
 		GenBuildFlags:            trimmedGenBuildFlags,
@@ -85,6 +91,7 @@ func generate(fname string) (err error) {
 		StubsOnly:                *stubs,
 		NoFormat:                 *noformat,
 		SimpleBytes:              *simpleBytes,
+		FloatFmt:                 trimmedFloatFmt,
 	}
 
 	if err := g.Run(); err != nil {

--- a/gen/encoder.go
+++ b/gen/encoder.go
@@ -452,7 +452,11 @@ func (g *Generator) genStructMarshaler(t reflect.Type) error {
 	if !g.noStdMarshalers {
 		fmt.Fprintln(g.out, "// MarshalJSON supports json.Marshaler interface")
 		fmt.Fprintln(g.out, "func (v "+typ+") MarshalJSON() ([]byte, error) {")
-		fmt.Fprintln(g.out, "  w := jwriter.Writer{}")
+		if g.floatFmt != "" {
+			fmt.Fprintf(g.out, "  w := jwriter.Writer{FloatFmt:\"%s\"}\n", g.floatFmt)
+		} else {
+			fmt.Fprintln(g.out, "  w := jwriter.Writer{}")
+		}
 		fmt.Fprintln(g.out, "  "+fname+"(&w, v)")
 		fmt.Fprintln(g.out, "  return w.Buffer.BuildBytes(), w.Error")
 		fmt.Fprintln(g.out, "}")

--- a/gen/generator.go
+++ b/gen/generator.go
@@ -39,6 +39,7 @@ type Generator struct {
 	fieldNamer               FieldNamer
 	simpleBytes              bool
 	skipMemberNameUnescaping bool
+	floatFmt                 string
 
 	// package path to local alias map for tracking imports
 	imports map[string]string
@@ -131,6 +132,11 @@ func (g *Generator) OmitEmpty() {
 // SimpleBytes triggers generate output bytes as slice byte
 func (g *Generator) SimpleBytes() {
 	g.simpleBytes = true
+}
+
+// SetFloatFmt sets the format for formatting float numbers using strconv.
+func (g *Generator) SetFloatFmt(fmt string) {
+	g.floatFmt = fmt
 }
 
 // addTypes requests to generate encoding/decoding funcs for the given type.

--- a/jwriter/writer.go
+++ b/jwriter/writer.go
@@ -25,6 +25,7 @@ type Writer struct {
 	Error        error
 	Buffer       buffer.Buffer
 	NoEscapeHTML bool
+	FloatFmt     string
 }
 
 // Size returns the size of the data that was written out.
@@ -237,26 +238,34 @@ func (w *Writer) Int64Str(n int64) {
 
 func (w *Writer) Float32(n float32) {
 	w.Buffer.EnsureSpace(20)
-	w.Buffer.Buf = strconv.AppendFloat(w.Buffer.Buf, float64(n), 'g', -1, 32)
+	w.Buffer.Buf = strconv.AppendFloat(w.Buffer.Buf, float64(n), w.floatFmt(), -1, 32)
 }
 
 func (w *Writer) Float32Str(n float32) {
 	w.Buffer.EnsureSpace(20)
 	w.Buffer.Buf = append(w.Buffer.Buf, '"')
-	w.Buffer.Buf = strconv.AppendFloat(w.Buffer.Buf, float64(n), 'g', -1, 32)
+	w.Buffer.Buf = strconv.AppendFloat(w.Buffer.Buf, float64(n), w.floatFmt(), -1, 32)
 	w.Buffer.Buf = append(w.Buffer.Buf, '"')
 }
 
 func (w *Writer) Float64(n float64) {
 	w.Buffer.EnsureSpace(20)
-	w.Buffer.Buf = strconv.AppendFloat(w.Buffer.Buf, n, 'g', -1, 64)
+	w.Buffer.Buf = strconv.AppendFloat(w.Buffer.Buf, n, w.floatFmt(), -1, 64)
 }
 
 func (w *Writer) Float64Str(n float64) {
 	w.Buffer.EnsureSpace(20)
 	w.Buffer.Buf = append(w.Buffer.Buf, '"')
-	w.Buffer.Buf = strconv.AppendFloat(w.Buffer.Buf, float64(n), 'g', -1, 64)
+	w.Buffer.Buf = strconv.AppendFloat(w.Buffer.Buf, float64(n), w.floatFmt(), -1, 64)
 	w.Buffer.Buf = append(w.Buffer.Buf, '"')
+}
+
+func (w *Writer) floatFmt() byte {
+	if len(w.FloatFmt) < 1 {
+		return 'g'
+	}
+
+	return w.FloatFmt[0]
 }
 
 func (w *Writer) Bool(v bool) {

--- a/tests/basic_test.go
+++ b/tests/basic_test.go
@@ -25,6 +25,7 @@ var testCases = []struct {
 	{&structsValue, structsString},
 	{&omitEmptyValue, omitEmptyString},
 	{&snakeStructValue, snakeStructString},
+	{&floatFmtStruct, floatFmtString},
 	{&omitEmptyDefaultValue, omitEmptyDefaultString},
 	{&optsValue, optsString},
 	{&rawValue, rawString},
@@ -244,7 +245,7 @@ func TestNestedMarshaler(t *testing.T) {
 		t.Errorf("Can't marshal NestedMarshaler: %s", err)
 	}
 
-	s2 := NestedMarshaler {
+	s2 := NestedMarshaler{
 		Value: &StructWithMarshaler{},
 	}
 

--- a/tests/float_format.go
+++ b/tests/float_format.go
@@ -1,0 +1,13 @@
+package tests
+
+//easyjson:json
+type FloatFmtStruct struct {
+	A float64 `json:"a"`
+	B float64 `json:"b"`
+}
+
+var floatFmtStruct = FloatFmtStruct{
+	A: 100000000,
+	B: 1000,
+}
+var floatFmtString = `{"a":100000000,"b":1000}`


### PR DESCRIPTION
This commit adds a float_format flag to easyjson which allows
users to change the float format used in strconv. The default flag
used is `g` by easyjson which is kept as is to avoid a breaking change.

If a user wishes, they can now provide a flag such as:
`	bin/easyjson -float_format='f' ./tests/float_format.go`

The g format converts long floats into 
e-notation. Using a flag such as 'f' might be necessary for certain
use cases to maintain backward compatibility.