### PR TITLE
Feature suggestion: add new option disallow_duplicate_fields

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,7 @@ generate: build
 	bin/easyjson -build_tags=use_easyjson -disable_members_unescape ./benchmark/data.go
 	bin/easyjson -disallow_unknown_fields ./tests/disallow_unknown.go
 	bin/easyjson -disable_members_unescape ./tests/members_unescaped.go
+	bin/easyjson -disallow_duplicate_fields ./tests/duplicate_fields.go
 
 test: generate
 	go test \

--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ Usage of easyjson:
     	only generate stubs for marshaler/unmarshaler funcs
   -disallow_unknown_fields
         return error if some unknown field in json appeared
+  -disallow_duplicate_fields
+        return error if a field appears in the json more than once
   -disable_members_unescape
         disable unescaping of \uXXXX string sequences in member names
 ```

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -32,6 +32,7 @@ type Generator struct {
 	OmitEmpty                bool
 	DisallowUnknownFields    bool
 	SkipMemberNameUnescaping bool
+	DisallowDuplicateFields  bool
 
 	OutName       string
 	BuildTags     string
@@ -136,6 +137,9 @@ func (g *Generator) writeMain() (path string, err error) {
 	}
 	if g.SkipMemberNameUnescaping {
 		fmt.Fprintln(f, "  g.SkipMemberNameUnescaping()")
+	}
+	if g.DisallowDuplicateFields {
+		fmt.Fprintln(f, "  g.DisallowDuplicateFields()")
 	}
 
 	sort.Strings(g.Types)

--- a/easyjson/main.go
+++ b/easyjson/main.go
@@ -30,6 +30,7 @@ var noformat = flag.Bool("noformat", false, "do not run 'gofmt -w' on output fil
 var specifiedName = flag.String("output_filename", "", "specify the filename of the output")
 var processPkg = flag.Bool("pkg", false, "process the whole package instead of just the given file")
 var disallowUnknownFields = flag.Bool("disallow_unknown_fields", false, "return error if any unknown field in json appeared")
+var disallowDuplicateFields = flag.Bool("disallow_duplicate_fields", false, "return error if a field appears in the json more than once")
 var skipMemberNameUnescaping = flag.Bool("disable_members_unescape", false, "don't perform unescaping of member names to improve performance")
 
 func generate(fname string) (err error) {
@@ -78,6 +79,7 @@ func generate(fname string) (err error) {
 		LowerCamelCase:           *lowerCamelCase,
 		NoStdMarshalers:          *noStdMarshalers,
 		DisallowUnknownFields:    *disallowUnknownFields,
+		DisallowDuplicateFields:  *disallowDuplicateFields,
 		SkipMemberNameUnescaping: *skipMemberNameUnescaping,
 		OmitEmpty:                *omitEmpty,
 		LeaveTemps:               *leaveTemps,

--- a/gen/generator.go
+++ b/gen/generator.go
@@ -39,6 +39,7 @@ type Generator struct {
 	fieldNamer               FieldNamer
 	simpleBytes              bool
 	skipMemberNameUnescaping bool
+	disallowDuplicateFields  bool
 
 	// package path to local alias map for tracking imports
 	imports map[string]string
@@ -121,6 +122,11 @@ func (g *Generator) DisallowUnknownFields() {
 // SkipMemberNameUnescaping instructs to skip member names unescaping to improve performance
 func (g *Generator) SkipMemberNameUnescaping() {
 	g.skipMemberNameUnescaping = true
+}
+
+// DisallowDuplicateFields instructs to error when a field is defined more than once
+func (g *Generator) DisallowDuplicateFields() {
+	g.disallowDuplicateFields = true
 }
 
 // OmitEmpty triggers `json=",omitempty"` behaviour by default.

--- a/tests/duplicate_fields.go
+++ b/tests/duplicate_fields.go
@@ -1,0 +1,7 @@
+package tests
+
+//easyjson:json
+type Dupl struct {
+	A int `json:"a"`
+	B int `json:"b"`
+}

--- a/tests/duplicate_fields_test.go
+++ b/tests/duplicate_fields_test.go
@@ -1,0 +1,39 @@
+package tests
+
+import (
+	"testing"
+
+	"github.com/mailru/easyjson"
+)
+
+func TestDuplicateFieldError(t *testing.T) {
+	var d Dupl
+	err := easyjson.Unmarshal([]byte(`{"a": 1, "a": 2}`), &d)
+	if err == nil || err.Error() != "duplicate field A" {
+		t.Error("want error, got ", err)
+	}
+}
+
+func TestDuplicateFieldNoError(t *testing.T) {
+	var d Dupl
+	err := easyjson.Unmarshal([]byte(`{"a": 1, "b": 2}`), &d)
+	if err != nil {
+		t.Error("unexpected error ", err)
+	}
+	if d != (Dupl{A: 1, B: 2}) {
+		t.Error("unexpected value ", d)
+	}
+}
+
+func TestDuplicateFieldNoErrorWithoutOption(t *testing.T) {
+	// We use the DisallowUnknown struct, which is generated without the duplicate field check enabled,
+	// so we expect to get no error and the last given value.
+	var d DisallowUnknown
+	err := easyjson.Unmarshal([]byte(`{"field_one": "a", "field_one": "b"}`), &d)
+	if err != nil {
+		t.Error("unexpected error ", err)
+	}
+	if d != (DisallowUnknown{FieldOne: "b"}) {
+		t.Error("unexpected value ", d)
+	}
+}


### PR DESCRIPTION
This option makes unmarshalling return an error if a field appears in the json more than once.

This option can be useful as a precaution against JSON Interoperability Vulnerabilities, see for example "Inconsistent Duplicate Key Precedence" in https://bishopfox.com/blog/json-interoperability-vulnerabilities

For reference, here is the generated code with the option:

```go
// Code generated by easyjson for marshaling/unmarshaling. DO NOT EDIT.

package tests

import (
	json "encoding/json"
	fmt "fmt"
	easyjson "github.com/mailru/easyjson"
	jlexer "github.com/mailru/easyjson/jlexer"
	jwriter "github.com/mailru/easyjson/jwriter"
)

// suppress unused package warning
var (
	_ *json.RawMessage
	_ *jlexer.Lexer
	_ *jwriter.Writer
	_ easyjson.Marshaler
)

func easyjson4f43fa15DecodeGithubComMailruEasyjsonTests(in *jlexer.Lexer, out *Dupl) {
	isTopLevel := in.IsStart()
	if in.IsNull() {
		if isTopLevel {
			in.Consumed()
		}
		in.Skip()
		return
	}
	var ASet bool
	var BSet bool
	in.Delim('{')
	for !in.IsDelim('}') {
		key := in.UnsafeFieldName(false)
		in.WantColon()
		if in.IsNull() {
			in.Skip()
			in.WantComma()
			continue
		}
		switch key {
		case "a":
			if ASet {
				in.AddError(fmt.Errorf("duplicate field A"))
			}
			out.A = int(in.Int())
			ASet = true
		case "b":
			if BSet {
				in.AddError(fmt.Errorf("duplicate field B"))
			}
			out.B = int(in.Int())
			BSet = true
		default:
			in.SkipRecursive()
		}
		in.WantComma()
	}
	in.Delim('}')
	if isTopLevel {
		in.Consumed()
	}
}
func easyjson4f43fa15EncodeGithubComMailruEasyjsonTests(out *jwriter.Writer, in Dupl) {
	out.RawByte('{')
	first := true
	_ = first
	{
		const prefix string = ",\"a\":"
		out.RawString(prefix[1:])
		out.Int(int(in.A))
	}
	{
		const prefix string = ",\"b\":"
		out.RawString(prefix)
		out.Int(int(in.B))
	}
	out.RawByte('}')
}

// MarshalJSON supports json.Marshaler interface
func (v Dupl) MarshalJSON() ([]byte, error) {
	w := jwriter.Writer{}
	easyjson4f43fa15EncodeGithubComMailruEasyjsonTests(&w, v)
	return w.Buffer.BuildBytes(), w.Error
}

// MarshalEasyJSON supports easyjson.Marshaler interface
func (v Dupl) MarshalEasyJSON(w *jwriter.Writer) {
	easyjson4f43fa15EncodeGithubComMailruEasyjsonTests(w, v)
}

// UnmarshalJSON supports json.Unmarshaler interface
func (v *Dupl) UnmarshalJSON(data []byte) error {
	r := jlexer.Lexer{Data: data}
	easyjson4f43fa15DecodeGithubComMailruEasyjsonTests(&r, v)
	return r.Error()
}

// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
func (v *Dupl) UnmarshalEasyJSON(l *jlexer.Lexer) {
	easyjson4f43fa15DecodeGithubComMailruEasyjsonTests(l, v)
}
```