### PR TITLE
Allow using pointer receivers, and use struct pointers for input parameters

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -32,6 +32,7 @@ type Generator struct {
 	OmitEmpty                bool
 	DisallowUnknownFields    bool
 	SkipMemberNameUnescaping bool
+	PtrReceivers             bool
 
 	OutName       string
 	BuildTags     string
@@ -69,15 +70,19 @@ func (g *Generator) writeStub() error {
 		fmt.Fprintln(f, ")")
 	}
 
+	inPtrPrefix := ""
+	if g.PtrReceivers {
+		inPtrPrefix = "*"
+	}
 	sort.Strings(g.Types)
 	for _, t := range g.Types {
 		fmt.Fprintln(f)
 		if !g.NoStdMarshalers {
-			fmt.Fprintln(f, "func (", t, ") MarshalJSON() ([]byte, error) { return nil, nil }")
+			fmt.Fprintln(f, "func (", inPtrPrefix, t, ") MarshalJSON() ([]byte, error) { return nil, nil }")
 			fmt.Fprintln(f, "func (*", t, ") UnmarshalJSON([]byte) error { return nil }")
 		}
 
-		fmt.Fprintln(f, "func (", t, ") MarshalEasyJSON(w *jwriter.Writer) {}")
+		fmt.Fprintln(f, "func (", inPtrPrefix, t, ") MarshalEasyJSON(w *jwriter.Writer) {}")
 		fmt.Fprintln(f, "func (*", t, ") UnmarshalEasyJSON(l *jlexer.Lexer) {}")
 		fmt.Fprintln(f)
 		fmt.Fprintln(f, "type EasyJSON_exporter_"+t+" *"+t)
@@ -136,6 +141,9 @@ func (g *Generator) writeMain() (path string, err error) {
 	}
 	if g.SkipMemberNameUnescaping {
 		fmt.Fprintln(f, "  g.SkipMemberNameUnescaping()")
+	}
+	if g.PtrReceivers {
+		fmt.Fprintln(f, "  g.PtrReceivers()")
 	}
 
 	sort.Strings(g.Types)

--- a/easyjson/main.go
+++ b/easyjson/main.go
@@ -31,6 +31,7 @@ var specifiedName = flag.String("output_filename", "", "specify the filename of 
 var processPkg = flag.Bool("pkg", false, "process the whole package instead of just the given file")
 var disallowUnknownFields = flag.Bool("disallow_unknown_fields", false, "return error if any unknown field in json appeared")
 var skipMemberNameUnescaping = flag.Bool("disable_members_unescape", false, "don't perform unescaping of member names to improve performance")
+var ptrReceivers = flag.Bool("ptr_receivers", false, "use pointer receivers for all generated marshaling methods")
 
 func generate(fname string) (err error) {
 	fInfo, err := os.Stat(fname)
@@ -85,6 +86,7 @@ func generate(fname string) (err error) {
 		StubsOnly:                *stubs,
 		NoFormat:                 *noformat,
 		SimpleBytes:              *simpleBytes,
+		PtrReceivers:             *ptrReceivers,
 	}
 
 	if err := g.Run(); err != nil {

--- a/gen/generator.go
+++ b/gen/generator.go
@@ -39,6 +39,7 @@ type Generator struct {
 	fieldNamer               FieldNamer
 	simpleBytes              bool
 	skipMemberNameUnescaping bool
+	ptrReceivers             bool
 
 	// package path to local alias map for tracking imports
 	imports map[string]string
@@ -121,6 +122,11 @@ func (g *Generator) DisallowUnknownFields() {
 // SkipMemberNameUnescaping instructs to skip member names unescaping to improve performance
 func (g *Generator) SkipMemberNameUnescaping() {
 	g.skipMemberNameUnescaping = true
+}
+
+// PtrReceivers instructs to use pointer receivers for marshaling methods of structs.
+func (g *Generator) PtrReceivers() {
+	g.ptrReceivers = true
 }
 
 // OmitEmpty triggers `json=",omitempty"` behaviour by default.


### PR DESCRIPTION
This PR changes two things:
- It adds a boolean `ptr_receivers` flag (default `false`), that, when set to true, causes generated `Marshal[Easy]JSON` methods to be generated with a pointer receiver instead of a value receiver.
- It causes internal, generated marshaling functions to expect input structs to be passed as pointers instead of values.

This PR unconditionally reverts the effect of #15 on the generated _internal_ functions, and allows conditionally reverting the effect of #15 on the generated _external_ (exported) methods.

The motivation is to allow easyjson to work with the new Google protobuf API (see fixed issue).

Fixes #348 .