### PR TITLE
Fix null key in map

### DIFF
--- a/gen/encoder.go
+++ b/gen/encoder.go
@@ -242,7 +242,7 @@ func (g *Generator) genTypeEncoderNoCheck(t reflect.Type, in string, tags fieldT
 
 		// NOTE: extra check for TextMarshaler. It overrides default methods.
 		if reflect.PtrTo(key).Implements(reflect.TypeOf((*encoding.TextMarshaler)(nil)).Elem()) {
-			fmt.Fprintln(g.out, ws+"    "+fmt.Sprintf("out.RawText(("+tmpVar+"Name).MarshalText()"+")"))
+			fmt.Fprintln(g.out, ws+"    "+fmt.Sprintf("out.RawBytesString(("+tmpVar+"Name).MarshalText()"+")"))
 		} else if keyEnc != "" {
 			fmt.Fprintln(g.out, ws+"    "+fmt.Sprintf(keyEnc, tmpVar+"Name"))
 		} else {

--- a/jwriter/writer.go
+++ b/jwriter/writer.go
@@ -67,6 +67,18 @@ func (w *Writer) RawString(s string) {
 	w.Buffer.AppendString(s)
 }
 
+// RawBytesString appends string from bytes to the buffer.
+func (w *Writer) RawBytesString(data []byte, err error) {
+	switch {
+	case w.Error != nil:
+		return
+	case err != nil:
+		w.Error = err
+	default:
+		w.String(string(data))
+	}
+}
+
 // Raw appends raw binary data to the buffer or sets the error if it is given. Useful for
 // calling with results of MarshalJSON-like functions.
 func (w *Writer) Raw(data []byte, err error) {

--- a/tests/data.go
+++ b/tests/data.go
@@ -545,21 +545,24 @@ type Maps struct {
 	InterfaceMap map[string]interface{}
 	NilMap       map[string]string
 
-	CustomMap map[Str]Str
+	CustomMap             map[Str]Str
+	CustomMapWithEmptyKey map[Str]Str
 }
 
 var mapsValue = Maps{
 	Map:          map[string]string{"A": "b"}, // only one item since map iteration is randomized
 	InterfaceMap: map[string]interface{}{"G": float64(1)},
 
-	CustomMap: map[Str]Str{"c": "d"},
+	CustomMap:             map[Str]Str{"c": "d"},
+	CustomMapWithEmptyKey: map[Str]Str{"": "d"},
 }
 
 var mapsString = `{` +
 	`"Map":{"A":"b"},` +
 	`"InterfaceMap":{"G":1},` +
 	`"NilMap":null,` +
-	`"CustomMap":{"c":"d"}` +
+	`"CustomMap":{"c":"d"},` +
+	`"CustomMapWithEmptyKey":{"":"d"}` +
 	`}`
 
 type NamedSlice []Str


### PR DESCRIPTION
В данный момент, если мы попытаемся замаршалить что-то такое, без кастомных маршаллеров
```
test := example.ExampleStruct{
    ExampleMap: map[example.ExampleKey]string{
	    "":     "val1",
	    "key2": "val2",
    },
}
```

то получим 
`{"example_map":{"":"val1","key2":"val2"}}`


Если в тип выше добавить кастомные маршаллеры
```
func (k ExampleKey) MarshalText() ([]byte, error) {
	return []byte(k), nil
}
```

То получим невалидный json
`{"example_map":{null:"val1","key2":"val2"}}`
И при попытке его обратно заанмаршалить получим ошибку:
`panic: parse error: expected string near offset 20 of 'example_map'`

Это происходит из-за использовании функции RawText
```
func (w *Writer) RawText(data []byte, err error) {
	switch {
	case w.Error != nil:
		return
	case err != nil:
		w.Error = err
	case len(data) > 0:
		w.String(string(data))
	default:
		w.RawString("null")
	}
}
```

Предлагаю убрать возможность возвращения null для ключей мапы, т.к. это приводит к неочевидному поведению
