### PR TITLE
Update go version, fix warnings

### DIFF
--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -8,7 +8,6 @@ package bootstrap
 import (
 	"fmt"
 	"go/format"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -87,7 +86,7 @@ func (g *Generator) writeStub() error {
 
 // writeMain creates a .go file that launches the generator if 'go run'.
 func (g *Generator) writeMain() (path string, err error) {
-	f, err := ioutil.TempFile(filepath.Dir(g.OutName), "easyjson-bootstrap")
+	f, err := os.CreateTemp(filepath.Dir(g.OutName), "easyjson-bootstrap")
 	if err != nil {
 		return "", err
 	}
@@ -204,7 +203,7 @@ func (g *Generator) Run() error {
 	}
 
 	// format file and write to out path
-	in, err := ioutil.ReadFile(f.Name())
+	in, err := os.ReadFile(f.Name())
 	if err != nil {
 		return err
 	}
@@ -212,5 +211,5 @@ func (g *Generator) Run() error {
 	if err != nil {
 		return err
 	}
-	return ioutil.WriteFile(g.OutName, out, 0644)
+	return os.WriteFile(g.OutName, out, 0644)
 }

--- a/buffer/pool.go
+++ b/buffer/pool.go
@@ -82,7 +82,7 @@ func (b *Buffer) EnsureSpace(s int) {
 	}
 }
 
-func (b *Buffer) ensureSpaceSlow(s int) {
+func (b *Buffer) ensureSpaceSlow(_ int) {
 	l := len(b.Buf)
 	if l > 0 {
 		if cap(b.toPool) != cap(b.Buf) {

--- a/gen/decoder.go
+++ b/gen/decoder.go
@@ -339,7 +339,7 @@ func (g *Generator) genStructFieldDecoder(t reflect.Type, f reflect.StructField)
 		return nil
 	}
 	if tags.intern && tags.noCopy {
-		return errors.New("Mutually exclusive tags are specified: 'intern' and 'nocopy'")
+		return errors.New("mutually exclusive tags are specified: 'intern' and 'nocopy'")
 	}
 
 	fmt.Fprintf(g.out, "    case %q:\n", jsonName)
@@ -354,7 +354,7 @@ func (g *Generator) genStructFieldDecoder(t reflect.Type, f reflect.StructField)
 	return nil
 }
 
-func (g *Generator) genRequiredFieldSet(t reflect.Type, f reflect.StructField) {
+func (g *Generator) genRequiredFieldSet(_ reflect.Type, f reflect.StructField) {
 	tags := parseFieldTags(f)
 
 	if !tags.required {

--- a/gen/decoder.go
+++ b/gen/decoder.go
@@ -62,13 +62,13 @@ func (g *Generator) genTypeDecoder(t reflect.Type, out string, tags fieldTags, i
 	ws := strings.Repeat("  ", indent)
 
 	unmarshalerIface := reflect.TypeOf((*easyjson.Unmarshaler)(nil)).Elem()
-	if reflect.PtrTo(t).Implements(unmarshalerIface) {
+	if reflect.PointerTo(t).Implements(unmarshalerIface) {
 		fmt.Fprintln(g.out, ws+"("+out+").UnmarshalEasyJSON(in)")
 		return nil
 	}
 
 	unmarshalerIface = reflect.TypeOf((*json.Unmarshaler)(nil)).Elem()
-	if reflect.PtrTo(t).Implements(unmarshalerIface) {
+	if reflect.PointerTo(t).Implements(unmarshalerIface) {
 		fmt.Fprintln(g.out, ws+"if data := in.Raw(); in.Ok() {")
 		fmt.Fprintln(g.out, ws+"  in.AddError( ("+out+").UnmarshalJSON(data) )")
 		fmt.Fprintln(g.out, ws+"}")
@@ -76,7 +76,7 @@ func (g *Generator) genTypeDecoder(t reflect.Type, out string, tags fieldTags, i
 	}
 
 	unmarshalerIface = reflect.TypeOf((*encoding.TextUnmarshaler)(nil)).Elem()
-	if reflect.PtrTo(t).Implements(unmarshalerIface) {
+	if reflect.PointerTo(t).Implements(unmarshalerIface) {
 		fmt.Fprintln(g.out, ws+"if data := in.UnsafeBytes(); in.Ok() {")
 		fmt.Fprintln(g.out, ws+"  in.AddError( ("+out+").UnmarshalText(data) )")
 		fmt.Fprintln(g.out, ws+"}")
@@ -89,19 +89,19 @@ func (g *Generator) genTypeDecoder(t reflect.Type, out string, tags fieldTags, i
 
 // returns true if the type t implements one of the custom unmarshaler interfaces
 func hasCustomUnmarshaler(t reflect.Type) bool {
-	t = reflect.PtrTo(t)
+	t = reflect.PointerTo(t)
 	return t.Implements(reflect.TypeOf((*easyjson.Unmarshaler)(nil)).Elem()) ||
 		t.Implements(reflect.TypeOf((*json.Unmarshaler)(nil)).Elem()) ||
 		t.Implements(reflect.TypeOf((*encoding.TextUnmarshaler)(nil)).Elem())
 }
 
 func hasUnknownsUnmarshaler(t reflect.Type) bool {
-	t = reflect.PtrTo(t)
+	t = reflect.PointerTo(t)
 	return t.Implements(reflect.TypeOf((*easyjson.UnknownsUnmarshaler)(nil)).Elem())
 }
 
 func hasUnknownsMarshaler(t reflect.Type) bool {
-	t = reflect.PtrTo(t)
+	t = reflect.PointerTo(t)
 	return t.Implements(reflect.TypeOf((*easyjson.UnknownsMarshaler)(nil)).Elem())
 }
 
@@ -271,7 +271,7 @@ func (g *Generator) genTypeDecoderNoCheck(t reflect.Type, out string, tags field
 
 		fmt.Fprintln(g.out, ws+"  for !in.IsDelim('}') {")
 		// NOTE: extra check for TextUnmarshaler. It overrides default methods.
-		if reflect.PtrTo(key).Implements(reflect.TypeOf((*encoding.TextUnmarshaler)(nil)).Elem()) {
+		if reflect.PointerTo(key).Implements(reflect.TypeOf((*encoding.TextUnmarshaler)(nil)).Elem()) {
 			fmt.Fprintln(g.out, ws+"    var key "+g.getType(key))
 			fmt.Fprintln(g.out, ws+"if data := in.UnsafeBytes(); in.Ok() {")
 			fmt.Fprintln(g.out, ws+"  in.AddError(key.UnmarshalText(data) )")

--- a/gen/encoder.go
+++ b/gen/encoder.go
@@ -95,19 +95,19 @@ func (g *Generator) genTypeEncoder(t reflect.Type, in string, tags fieldTags, in
 	ws := strings.Repeat("  ", indent)
 
 	marshalerIface := reflect.TypeOf((*easyjson.Marshaler)(nil)).Elem()
-	if reflect.PtrTo(t).Implements(marshalerIface) {
+	if reflect.PointerTo(t).Implements(marshalerIface) {
 		fmt.Fprintln(g.out, ws+"("+in+").MarshalEasyJSON(out)")
 		return nil
 	}
 
 	marshalerIface = reflect.TypeOf((*json.Marshaler)(nil)).Elem()
-	if reflect.PtrTo(t).Implements(marshalerIface) {
+	if reflect.PointerTo(t).Implements(marshalerIface) {
 		fmt.Fprintln(g.out, ws+"out.Raw( ("+in+").MarshalJSON() )")
 		return nil
 	}
 
 	marshalerIface = reflect.TypeOf((*encoding.TextMarshaler)(nil)).Elem()
-	if reflect.PtrTo(t).Implements(marshalerIface) {
+	if reflect.PointerTo(t).Implements(marshalerIface) {
 		fmt.Fprintln(g.out, ws+"out.RawText( ("+in+").MarshalText() )")
 		return nil
 	}
@@ -118,7 +118,7 @@ func (g *Generator) genTypeEncoder(t reflect.Type, in string, tags fieldTags, in
 
 // returns true if the type t implements one of the custom marshaler interfaces
 func hasCustomMarshaler(t reflect.Type) bool {
-	t = reflect.PtrTo(t)
+	t = reflect.PointerTo(t)
 	return t.Implements(reflect.TypeOf((*easyjson.Marshaler)(nil)).Elem()) ||
 		t.Implements(reflect.TypeOf((*json.Marshaler)(nil)).Elem()) ||
 		t.Implements(reflect.TypeOf((*encoding.TextMarshaler)(nil)).Elem())
@@ -241,7 +241,7 @@ func (g *Generator) genTypeEncoderNoCheck(t reflect.Type, in string, tags fieldT
 		fmt.Fprintln(g.out, ws+"    if "+tmpVar+"First { "+tmpVar+"First = false } else { out.RawByte(',') }")
 
 		// NOTE: extra check for TextMarshaler. It overrides default methods.
-		if reflect.PtrTo(key).Implements(reflect.TypeOf((*encoding.TextMarshaler)(nil)).Elem()) {
+		if reflect.PointerTo(key).Implements(reflect.TypeOf((*encoding.TextMarshaler)(nil)).Elem()) {
 			fmt.Fprintln(g.out, ws+"    "+fmt.Sprintf("out.RawText(("+tmpVar+"Name).MarshalText()"+")"))
 		} else if keyEnc != "" {
 			fmt.Fprintln(g.out, ws+"    "+fmt.Sprintf(keyEnc, tmpVar+"Name"))
@@ -299,7 +299,7 @@ func (g *Generator) interfaceIsJSONMarshaller(t reflect.Type) bool {
 
 func (g *Generator) notEmptyCheck(t reflect.Type, v string) string {
 	optionalIface := reflect.TypeOf((*easyjson.Optional)(nil)).Elem()
-	if reflect.PtrTo(t).Implements(optionalIface) {
+	if reflect.PointerTo(t).Implements(optionalIface) {
 		return "(" + v + ").IsDefined()"
 	}
 

--- a/gen/generator.go
+++ b/gen/generator.go
@@ -517,7 +517,7 @@ func camelToSnake(name string) string {
 	if lastUpper != 0 {
 		ret.WriteRune(unicode.ToLower(lastUpper))
 	}
-	return string(ret.Bytes())
+	return ret.String()
 }
 
 func (SnakeCaseFieldNamer) GetJSONFieldName(t reflect.Type, f reflect.StructField) string {

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,3 @@
 module github.com/mailru/easyjson
 
-go 1.12
-
-require github.com/josharian/intern v1.0.0
+go 1.22.5

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,0 @@
-github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
-github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=

--- a/helpers.go
+++ b/helpers.go
@@ -3,7 +3,6 @@ package easyjson
 
 import (
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strconv"
 	"unsafe"
@@ -104,7 +103,7 @@ func Unmarshal(data []byte, v Unmarshaler) error {
 
 // UnmarshalFromReader reads all the data in the reader and decodes as JSON into the object.
 func UnmarshalFromReader(r io.Reader, v Unmarshaler) error {
-	data, err := ioutil.ReadAll(r)
+	data, err := io.ReadAll(r)
 	if err != nil {
 		return err
 	}

--- a/intern/intern.go
+++ b/intern/intern.go
@@ -1,0 +1,44 @@
+// Package intern interns strings.
+// Interning is best effort only.
+// Interned strings may be removed automatically
+// at any time without notification.
+// All functions may be called concurrently
+// with themselves and each other.
+package intern
+
+import "sync"
+
+var (
+	pool sync.Pool = sync.Pool{
+		New: func() interface{} {
+			return make(map[string]string)
+		},
+	}
+)
+
+// String returns s, interned.
+func String(s string) string {
+	m := pool.Get().(map[string]string)
+	c, ok := m[s]
+	if ok {
+		pool.Put(m)
+		return c
+	}
+	m[s] = s
+	pool.Put(m)
+	return s
+}
+
+// Bytes returns b converted to a string, interned.
+func Bytes(b []byte) string {
+	m := pool.Get().(map[string]string)
+	c, ok := m[string(b)]
+	if ok {
+		pool.Put(m)
+		return c
+	}
+	s := string(b)
+	m[s] = s
+	pool.Put(m)
+	return s
+}

--- a/intern/intern_test.go
+++ b/intern/intern_test.go
@@ -1,0 +1,63 @@
+//go:build !race
+// +build !race
+
+// When -race is enabled, sync.Pool is a no-op,
+// which will cause these tests to fail
+// and these benchmarks to be misleading.
+
+package intern
+
+import (
+	"bytes"
+	"testing"
+	"unsafe"
+)
+
+func TestString(t *testing.T) {
+	s := "abcde"
+	sub := String(s[1:4])
+	interned := String("bcd")
+	want := unsafe.StringData(sub)
+	got := unsafe.StringData(interned)
+	if want != got {
+		t.Errorf("failed to intern string")
+	}
+}
+
+func TestBytes(t *testing.T) {
+	s := bytes.Repeat([]byte("abc"), 100)
+	n := testing.AllocsPerRun(100, func() {
+		for i := 0; i < 100; i++ {
+			_ = Bytes(s[i*len("abc") : (i+1)*len("abc")])
+		}
+	})
+	if n > 0 {
+		t.Errorf("Bytes allocated %d, want 0", int(n))
+	}
+}
+
+func BenchmarkString(b *testing.B) {
+	in := "hello brad"
+	b.ReportAllocs()
+	b.SetBytes(int64(len(in)))
+	b.RunParallel(func(pb *testing.PB) {
+		var s string
+		for pb.Next() {
+			s = String(in[1:5])
+		}
+		_ = s
+	})
+}
+
+func BenchmarkBytes(b *testing.B) {
+	in := []byte("hello brad")
+	b.ReportAllocs()
+	b.SetBytes(int64(len(in)))
+	b.RunParallel(func(pb *testing.PB) {
+		var s string
+		for pb.Next() {
+			s = Bytes(in[1:5])
+		}
+		_ = s
+	})
+}

--- a/jlexer/bytestostr.go
+++ b/jlexer/bytestostr.go
@@ -2,8 +2,8 @@
 // easyjson_nounsafe nor appengine build tag is set. See README notes
 // for more details.
 
-//+build !easyjson_nounsafe
-//+build !appengine
+//go:build !easyjson_nounsafe && !appengine
+// +build !easyjson_nounsafe,!appengine
 
 package jlexer
 

--- a/jlexer/bytestostr_nounsafe.go
+++ b/jlexer/bytestostr_nounsafe.go
@@ -1,7 +1,8 @@
 // This file is included to the build if any of the buildtags below
 // are defined. Refer to README notes for more details.
 
-//+build easyjson_nounsafe appengine
+//go:build easyjson_nounsafe || appengine
+// +build easyjson_nounsafe appengine
 
 package jlexer
 

--- a/jlexer/lexer.go
+++ b/jlexer/lexer.go
@@ -16,7 +16,7 @@ import (
 	"unicode/utf16"
 	"unicode/utf8"
 
-	"github.com/josharian/intern"
+	"github.com/mailru/easyjson/intern"
 )
 
 // TokenKind determines type of a token.
@@ -157,7 +157,6 @@ func (r *Lexer) FetchToken() {
 		}
 	}
 	r.fatalError = io.EOF
-	return
 }
 
 // isTokenEnd returns true if the char can follow a non-delimiter token

--- a/jlexer/lexer_test.go
+++ b/jlexer/lexer_test.go
@@ -98,7 +98,7 @@ func TestBytes(t *testing.T) {
 		l := Lexer{Data: []byte(test.toParse)}
 
 		got := l.Bytes()
-		if bytes.Compare(got, []byte(test.want)) != 0 {
+		if !bytes.Equal(got, []byte(test.want)) {
 			t.Errorf("[%d, %q] Bytes() = %v; want: %v", i, test.toParse, got, []byte(test.want))
 		}
 		err := l.Error()

--- a/parser/pkgpath.go
+++ b/parser/pkgpath.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"go/build"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
@@ -111,7 +110,7 @@ func getModulePath(goModPath string) string {
 		pkgPathFromGoModCache.Unlock()
 	}()
 
-	data, err := ioutil.ReadFile(goModPath)
+	data, err := os.ReadFile(goModPath)
 	if err != nil {
 		return ""
 	}

--- a/tests/basic_test.go
+++ b/tests/basic_test.go
@@ -244,7 +244,7 @@ func TestNestedMarshaler(t *testing.T) {
 		t.Errorf("Can't marshal NestedMarshaler: %s", err)
 	}
 
-	s2 := NestedMarshaler {
+	s2 := NestedMarshaler{
 		Value: &StructWithMarshaler{},
 	}
 

--- a/tests/nested_marshaler.go
+++ b/tests/nested_marshaler.go
@@ -8,7 +8,7 @@ import (
 
 //easyjson:json
 type NestedMarshaler struct {
-	Value easyjson.MarshalerUnmarshaler
+	Value  easyjson.MarshalerUnmarshaler
 	Value2 int
 }
 
@@ -23,4 +23,3 @@ func (s *StructWithMarshaler) UnmarshalEasyJSON(w *jlexer.Lexer) {
 func (s *StructWithMarshaler) MarshalEasyJSON(w *jwriter.Writer) {
 	w.Int(s.Value)
 }
-


### PR DESCRIPTION
Changes on this PR:

1. There were some warnings in the `lexer.go` which is fixed in this PR.
2. The Golang had a lot of security updates on its new versions, I've just updated the Golang version.
3. The Intern package is a tiny package but adds dependency, just moved it to this repo.
4. `io/ioutil` is deprecated, and replaced with `io` and `os`.
5. `reflect.PtrTo` is deprecated, and replaced with `reflect.PointerTo`.
