### PR TITLE
Fix unmarshal null to existing value

### DIFF
--- a/gen/decoder.go
+++ b/gen/decoder.go
@@ -320,7 +320,6 @@ func (g *Generator) genTypeDecoderNoCheck(t reflect.Type, out string, tags field
 		return fmt.Errorf("don't know how to decode %v", t)
 	}
 	return nil
-
 }
 
 func (g *Generator) interfaceIsEasyjsonUnmarshaller(t reflect.Type) bool {
@@ -514,11 +513,6 @@ func (g *Generator) genStructDecoder(t reflect.Type) error {
 	fmt.Fprintln(g.out, "  for !in.IsDelim('}') {")
 	fmt.Fprintf(g.out, "    key := in.UnsafeFieldName(%v)\n", g.skipMemberNameUnescaping)
 	fmt.Fprintln(g.out, "    in.WantColon()")
-	fmt.Fprintln(g.out, "    if in.IsNull() {")
-	fmt.Fprintln(g.out, "       in.Skip()")
-	fmt.Fprintln(g.out, "       in.WantComma()")
-	fmt.Fprintln(g.out, "       continue")
-	fmt.Fprintln(g.out, "    }")
 
 	fmt.Fprintln(g.out, "    switch key {")
 	for _, f := range fs {

--- a/tests/basic_test.go
+++ b/tests/basic_test.go
@@ -205,7 +205,6 @@ func TestEncodingFlags(t *testing.T) {
 			t.Errorf("[%v] easyjson.Marshal(%+v) = %v; want %v", i, test.In, v, test.Want)
 		}
 	}
-
 }
 
 func TestNestedEasyJsonMarshal(t *testing.T) {
@@ -327,5 +326,19 @@ func TestNil(t *testing.T) {
 
 	if s := w.Body.String(); s != "null" {
 		t.Errorf("Wanted null, got %q", s)
+	}
+}
+
+func TestUnmarshalNull(t *testing.T) {
+	p := primitiveTypesValue
+
+	data := `{"Ptr":null}`
+
+	if err := easyjson.Unmarshal([]byte(data), &p); err != nil {
+		t.Errorf("easyjson.Unmarshal() error: %v", err)
+	}
+
+	if p.Ptr != nil {
+		t.Errorf("Wanted nil, got %q", *p.Ptr)
 	}
 }


### PR DESCRIPTION
Unmarshaling null value on an existing field does not set it to nil.

The generated unmarshal code today adds this block of code that skips the field if it is null: https://github.com/mailru/easyjson/blob/853c4976cc1dc774f4653967e1ed9bae04ffbbb5/gen/decoder.go#L517-L521

This means the field is skipped and does not get set to nil.

However, there is already an `if in.IsNull()` check on the individual field that sets the field to nil as expected: https://github.com/mailru/easyjson/blob/529b1f6f7ec18fbae380d7ce72d38061e5201498/gen/decoder.go#L234-L240

So removing the first check fixes this issue.

The added test fails today because it does not overwrite the `Ptr` field to nil, which is the stdlib behavior as shown here: https://goplay.tools/snippet/8Y3_1RK1C3u

As far as I can tell, the removed code should not affect anything else as the check is handled correctly after anyways, but please let me know if I am missing anything and how we can achieve the same behavior as stdlib.