### PR TITLE
Feature: User specified initial capacity for slices

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,8 @@ generate: build
  		./tests/nothing.go \
  		./tests/errors.go \
  		./tests/html.go \
- 		./tests/type_declaration_skip.go
+ 		./tests/type_declaration_skip.go \
+ 		./tests/init_cap.go
 	bin/easyjson \
 		./tests/nested_easy.go \
 		./tests/named_type.go \

--- a/gen/decoder.go
+++ b/gen/decoder.go
@@ -148,10 +148,12 @@ func (g *Generator) genTypeDecoderNoCheck(t reflect.Type, out string, tags field
 			fmt.Fprintln(g.out, ws+"}")
 
 		} else {
-
 			capacity := 1
 			if elem.Size() > 0 {
 				capacity = minSliceBytes / int(elem.Size())
+			}
+			if tags.initialCapacity > 0 {
+				capacity = tags.initialCapacity
 			}
 
 			fmt.Fprintln(g.out, ws+"if in.IsNull() {")

--- a/gen/encoder.go
+++ b/gen/encoder.go
@@ -53,18 +53,22 @@ var primitiveStringEncoders = map[reflect.Kind]string{
 type fieldTags struct {
 	name string
 
-	omit        bool
-	omitEmpty   bool
-	noOmitEmpty bool
-	asString    bool
-	required    bool
-	intern      bool
-	noCopy      bool
+	omit            bool
+	omitEmpty       bool
+	noOmitEmpty     bool
+	asString        bool
+	required        bool
+	intern          bool
+	noCopy          bool
+	initialCapacity int
 }
+
+const defaultCapacity int = -1
 
 // parseFieldTags parses the json field tag into a structure.
 func parseFieldTags(f reflect.StructField) fieldTags {
 	var ret fieldTags
+	ret.initialCapacity = defaultCapacity
 
 	for i, s := range strings.Split(f.Tag.Get("json"), ",") {
 		switch {
@@ -84,6 +88,17 @@ func parseFieldTags(f reflect.StructField) fieldTags {
 			ret.intern = true
 		case s == "nocopy":
 			ret.noCopy = true
+		}
+	}
+
+	for i, s := range strings.Split(f.Tag.Get("initialCap"), ",") {
+		switch {
+		case i == 0:
+			capacity, err := strconv.Atoi(s)
+			if err != nil || capacity <= 0 {
+				capacity = defaultCapacity
+			}
+			ret.initialCapacity = capacity
 		}
 	}
 

--- a/tests/basic_test.go
+++ b/tests/basic_test.go
@@ -59,6 +59,9 @@ var testCases = []struct {
 	{&myTypeDeclaredValue, myTypeDeclaredString},
 	{&myTypeNotSkippedValue, myTypeNotSkippedString},
 	{&intern, internString},
+	{&noInitCap, noInitCapString},
+	{&initCap, initCapString},
+	{&invalidInitCap, invalidInitCapString},
 }
 
 func TestMarshal(t *testing.T) {
@@ -243,7 +246,7 @@ func TestNestedMarshaler(t *testing.T) {
 		t.Errorf("Can't marshal NestedMarshaler: %s", err)
 	}
 
-	s2 := NestedMarshaler {
+	s2 := NestedMarshaler{
 		Value: &StructWithMarshaler{},
 	}
 

--- a/tests/init_cap.go
+++ b/tests/init_cap.go
@@ -1,0 +1,25 @@
+package tests
+
+//easyjson:json
+type NoInitCap struct {
+	Field []string `json:"field"`
+}
+
+//easyjson:json
+type InitCap struct {
+	Field []string `json:"field" initialCap:"10"`
+}
+
+//easyjson:json
+type InvalidInitCap struct {
+	Field []string `json:"field" initialCap:"-3"`
+}
+
+var noInitCap = NoInitCap{Field: []string{"elem"}}
+var noInitCapString = `{"field":["elem"]}`
+
+var initCap = InitCap{Field: []string{"elem"}}
+var initCapString = `{"field":["elem"]}`
+
+var invalidInitCap = InvalidInitCap{Field: []string{"elem"}}
+var invalidInitCapString = `{"field":["elem"]}`

--- a/tests/init_cap_test.go
+++ b/tests/init_cap_test.go
@@ -1,0 +1,40 @@
+package tests
+
+import (
+	"github.com/mailru/easyjson"
+	"testing"
+)
+
+func TestTagInitialCapacity(t *testing.T) {
+	data := []byte(`{"field":["elem"]}`)
+
+	var n NoInitCap
+	err := easyjson.Unmarshal(data, &n)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if cap(n.Field) != 4 {
+		t.Fatalf("wrong slice capacity: %d", cap(n.Field))
+	}
+
+	var c InitCap
+	err = easyjson.Unmarshal(data, &c)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if cap(c.Field) != 10 {
+		t.Fatalf("wrong slice capacity: %d", cap(c.Field))
+	}
+
+	var i InvalidInitCap
+	err = easyjson.Unmarshal(data, &i)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if cap(i.Field) != 4 {
+		t.Fatalf("wrong slice capacity: %d", cap(i.Field))
+	}
+}


### PR DESCRIPTION
## Description
This feature enhances the unmarshalling performance for slices when the estimated capacity is known in advance. By preallocating the slice with the estimated capacity, it minimizes the need for reallocations and reduces the copying of elements in the underlying array.

## Key Improvements
- Optimized memory allocation for slices with predictable sizes.
- Reduced overhead from unnecessary reallocations and element copying during unmarshalling.

This was requested in #286  