### PR TITLE
Fix unmarshal null values for non-pointer fields

### DIFF
--- a/tests/basic_test.go
+++ b/tests/basic_test.go
@@ -330,12 +330,19 @@ func TestNil(t *testing.T) {
 }
 
 func TestUnmarshalNull(t *testing.T) {
-	p := primitiveTypesValue
+	p := PrimitiveTypes{
+		String: str,
+		Ptr:    &str,
+	}
 
-	data := `{"Ptr":null}`
+	data := `{"String":null,"Ptr":null}`
 
 	if err := easyjson.Unmarshal([]byte(data), &p); err != nil {
 		t.Errorf("easyjson.Unmarshal() error: %v", err)
+	}
+
+	if p.String != str {
+		t.Errorf("Wanted %q, got %q", str, p.String)
 	}
 
 	if p.Ptr != nil {


### PR DESCRIPTION
#407 fixed the issue where an explicit null field did not reset the value, but a regression was introduced where previously it skipped any null values for non-pointer fields, that now returns an error.

This PR adds a `IsNull()` check before each unmarshal and the result is the same behavior as I see with stdlib now.

eg. stdlib ignores any null values for non-pointer fields: https://goplay.tools/snippet/dEJi7819RKc

The updated unit test also validates this behavior.

Without this change, the updated test fails to unmarshal:

```
--- FAIL: TestUnmarshalNull (0.00s)
    basic_test.go:341: easyjson.Unmarshal() error: parse error: expected string near offset 14 of 'String'
    basic_test.go:345: Wanted "bla", got ""
    basic_test.go:349: Wanted nil, got "bla"
```