### PR TITLE
Bugfix: do not generate invalid JSON when float value is +Inf, -Inf or NaN

### DIFF
--- a/tests/errors.go
+++ b/tests/errors.go
@@ -24,3 +24,9 @@ type ErrorNestedStruct struct {
 
 //easyjson:json
 type ErrorIntMap map[uint32]string
+
+//easyjson:json
+type ErrorFloatTypes struct {
+	Float64 float64 `json:"float64"`
+	Float32 float32 `json:"float32"`
+}

--- a/tests/errors_test.go
+++ b/tests/errors_test.go
@@ -1,6 +1,7 @@
 package tests
 
 import (
+	"math"
 	"testing"
 
 	"github.com/mailru/easyjson/jlexer"
@@ -280,6 +281,43 @@ func TestMultipleErrorsIntMap(t *testing.T) {
 			if e.Offset != test.Offsets[ii] {
 				t.Errorf("[%d] TestMultipleErrorsInt(): offset[%d]: want %d, got %d", i, ii, test.Offsets[ii], e.Offset)
 			}
+		}
+	}
+}
+
+func TestUnsupportedFloatValues(t *testing.T) {
+	for i, test := range []struct {
+		Value       ErrorFloatTypes
+		ExpectedErr string
+	}{
+		{
+			Value:       ErrorFloatTypes{Float64: math.NaN()},
+			ExpectedErr: "json: unsupported value: NaN",
+		},
+		{
+			Value:       ErrorFloatTypes{Float64: math.Inf(1)},
+			ExpectedErr: "json: unsupported value: +Inf",
+		},
+		{
+			Value:       ErrorFloatTypes{Float64: math.Inf(-1)},
+			ExpectedErr: "json: unsupported value: -Inf",
+		},
+		{
+			Value:       ErrorFloatTypes{Float32: float32(math.NaN())},
+			ExpectedErr: "json: unsupported value: NaN",
+		},
+		{
+			Value:       ErrorFloatTypes{Float32: float32(math.Inf(1))},
+			ExpectedErr: "json: unsupported value: +Inf",
+		},
+		{
+			Value:       ErrorFloatTypes{Float32: float32(math.Inf(-1))},
+			ExpectedErr: "json: unsupported value: -Inf",
+		},
+	} {
+		_, err := test.Value.MarshalJSON()
+		if err == nil || err.Error() != test.ExpectedErr {
+			t.Errorf("[%d] TestUnsupportedFloatValues(): error: want %s, got %v", i, test.ExpectedErr, err)
 		}
 	}
 }


### PR DESCRIPTION
This PR solves [issue #134](https://github.com/mailru/easyjson/issues/134) - Invalid JSON generated for NaN and Inf.

Context:
The following code generates invalid JSON, which cannot be unmarshalled either via easyjson or builtin go encoding/json package.

```
package main

import (
	"fmt"
	"math"
)

//go:generate easyjson $GOFILE

//easyjson:json
type Struct struct {
	Float1 float64
	Float2 float64
	Float3 float64
}

func main() {
	s := Struct{
		Float1: math.NaN(),
		Float2: math.Inf(1),
		Float3: math.Inf(-1),
	}
	b, err := s.MarshalJSON()
	if err != nil {
		fmt.Println(err)
		return
	}
	fmt.Println(string(b))
	var s2 Struct

	if err := s2.UnmarshalJSON(b); err != nil {
		fmt.Println(err)
		return
	}
	fmt.Println(s2)
}
```

Output:
```
{"Float1":NaN,"Float2":+Inf,"Float3":-Inf}
parse error: syntax error near offset 10 of 'NaN,"Float...'
```

Suggested solution:

In `jwriter/writer.go`: check floats for NaN, +Inf, -Inf values before passing them into `strconv.AppendFloat`, and write `w.Error = "json: unsupported value: ..."` if it is so